### PR TITLE
feat: add RWMutex to protect messagers

### DIFF
--- a/cmd/protoc-gen-go-tableau-loader/hub.go
+++ b/cmd/protoc-gen-go-tableau-loader/hub.go
@@ -19,6 +19,8 @@ func generateHub(gen *protogen.Plugin) {
 
 	for _, messager := range messagers {
 		g.P("func (h *Hub) Get", messager, "() *", messager, " {")
+		g.P("h.mu.RLock()")
+		g.P("defer h.mu.RUnlock()")
 		g.P(`msger := h.messagerMap["`, messager, `"]`)
 		g.P("if msger != nil {")
 		g.P("if conf, ok := msger.(*", messager, "); ok {")
@@ -83,6 +85,7 @@ type Filter interface {
 
 // Hub is the holder for managing configurations.
 type Hub struct {
+	mu          sync.RWMutex
 	messagerMap MessagerMap
 }
 
@@ -103,6 +106,8 @@ func (h *Hub) NewMessagerMap(filter Filter) MessagerMap {
 }
 
 func (h *Hub) SetMessagerMap(messagerMap MessagerMap) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	h.messagerMap = messagerMap
 }
 


### PR DESCRIPTION
- **Concurrent Access**: Direct concurrent access to a map (including reassigning it) is not safe.
- **Synchronization**: Use a sync.Mutex or sync.RWMutex to protect access to the map.
- **Reassigning**: If you need to reassign a map, ensure that no other goroutines are accessing it at the same time, or use a mutex to lock access during the reassignment.