### PR TITLE
fix(go): support bool key for OrderedMap accessers

### DIFF
--- a/cmd/protoc-gen-go-tableau-loader/hub.go
+++ b/cmd/protoc-gen-go-tableau-loader/hub.go
@@ -73,6 +73,13 @@ func getRegistrar() *Registrar {
 	return registrarSingleton
 }
 
+func BoolToInt(ok bool) int {
+	if ok {
+		return 1
+	}
+	return 0
+}
+
 func register(name string, gen MessagerGenerator) {
 	getRegistrar().register(name, gen)
 }


### PR DESCRIPTION
Bool is not an ordered type in golang, so convert it to int when using it as ordered map key.

In [constraints](https://cs.opensource.google/go/x/exp/+/864b3d6c:constraints/)/[constraints.go](https://cs.opensource.google/go/x/exp/+/864b3d6c:constraints/constraints.go):
```
// Ordered is a constraint that permits any ordered type: any type
// that supports the operators < <= >= >.
// If future releases of Go add new ordered types,
// this constraint will be modified to include them.
type Ordered interface {
	Integer | Float | ~string
}
```