### PR TITLE
feat(cpp/go): add GetLastLoadedTime() method for hub

### DIFF
--- a/cmd/protoc-gen-cpp-tableau-loader/embed/hub.pc.cc
+++ b/cmd/protoc-gen-cpp-tableau-loader/embed/hub.pc.cc
@@ -251,6 +251,7 @@ void Hub::SetMessagerContainer(MessagerContainer msger_container) {
   // replace with thread-safe guarantee.
   std::unique_lock<std::mutex> lock(mutex_);
   msger_container_ = msger_container;
+  last_loaded_time_ = std::time(nullptr);
 }
 
 MessagerContainer Hub::GetMessagerContainerWithProvider() const {

--- a/cmd/protoc-gen-cpp-tableau-loader/embed/hub.pc.cc
+++ b/cmd/protoc-gen-cpp-tableau-loader/embed/hub.pc.cc
@@ -146,7 +146,7 @@ bool LoadMessage(const std::string& dir, google::protobuf::Message& message, For
         break;
       }
       default: {
-        g_err_msg = "unsupported format: %d" + std::to_string(static_cast<int>(fmt));
+        g_err_msg = "unsupported format: " + std::to_string(static_cast<int>(fmt));
         return false;
       }
     }
@@ -167,7 +167,7 @@ bool LoadMessage(const std::string& dir, google::protobuf::Message& message, For
       return Bin2Message(content, message);
     }
     default: {
-      g_err_msg = "unsupported format: %d" + std::to_string(static_cast<int>(fmt));
+      g_err_msg = "unsupported format: " + std::to_string(static_cast<int>(fmt));
       return false;
     }
   }

--- a/cmd/protoc-gen-cpp-tableau-loader/embed/hub.pc.h
+++ b/cmd/protoc-gen-cpp-tableau-loader/embed/hub.pc.h
@@ -158,7 +158,7 @@ class Hub {
   // Loading scheduler.
   internal::Scheduler* sched_ = nullptr;
   // Last loaded time
-  std::time_t last_loaded_time_ = std::time(nullptr);
+  std::time_t last_loaded_time_ = 0;
 };
 
 template <typename T>

--- a/cmd/protoc-gen-cpp-tableau-loader/embed/hub.pc.h
+++ b/cmd/protoc-gen-cpp-tableau-loader/embed/hub.pc.h
@@ -137,6 +137,7 @@ class Hub {
   template <typename T, typename U, typename... Args>
   const U* GetOrderedMap(Args... args) const;
 
+  // GetLastLoadedTime returns the time when hub's msger_container_ was last set.
   inline std::time_t GetLastLoadedTime() const { return last_loaded_time_; }
 
  private:

--- a/cmd/protoc-gen-cpp-tableau-loader/embed/hub.pc.h
+++ b/cmd/protoc-gen-cpp-tableau-loader/embed/hub.pc.h
@@ -2,6 +2,7 @@
 #include <google/protobuf/util/json_util.h>
 
 #include <cstddef>
+#include <ctime>
 #include <functional>
 #include <mutex>
 #include <string>
@@ -136,6 +137,8 @@ class Hub {
   template <typename T, typename U, typename... Args>
   const U* GetOrderedMap(Args... args) const;
 
+  inline std::time_t GetLastLoadedTime() const { return last_loaded_time_; }
+
  private:
   MessagerContainer LoadNewMessagerContainer(const std::string& dir, Filter filter = nullptr,
                                              Format fmt = Format::kJSON, const LoadOptions* options = nullptr);
@@ -154,6 +157,8 @@ class Hub {
   MessagerContainerProvider msger_container_provider_;
   // Loading scheduler.
   internal::Scheduler* sched_ = nullptr;
+  // Last loaded time
+  std::time_t last_loaded_time_ = std::time(nullptr);
 };
 
 template <typename T>

--- a/cmd/protoc-gen-go-tableau-loader/hub.go
+++ b/cmd/protoc-gen-go-tableau-loader/hub.go
@@ -34,6 +34,7 @@ func generateHub(gen *protogen.Plugin) {
 const staticHubContent = `import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/tableauio/tableau/format"
@@ -137,12 +138,14 @@ func BoolToInt(ok bool) int {
 
 // Hub is the messager manager.
 type Hub struct {
-	messagerMap MessagerMap
+	messagerMap    MessagerMap
+	lastLoadedTime time.Time
 }
 
 func NewHub() *Hub {
 	return &Hub{
-		messagerMap: MessagerMap{},
+		messagerMap:    MessagerMap{},
+		lastLoadedTime: time.Now(),
 	}
 }
 
@@ -160,6 +163,7 @@ func (h *Hub) NewMessagerMap(filter Filter) MessagerMap {
 // SetMessagerMap sets hub's inner field messagerMap.
 func (h *Hub) SetMessagerMap(messagerMap MessagerMap) {
 	h.messagerMap = messagerMap
+	h.lastLoadedTime = time.Now()
 }
 
 // GetMessager finds and returns the specified Messenger in hub.
@@ -199,6 +203,11 @@ func (h *Hub) Store(dir string, filter Filter, format format.Format, options ...
 		}
 	}
 	return nil
+}
+
+// GetLastLoadedTime returns the time when hub's messagerMap was last set.
+func (h *Hub) GetLastLoadedTime() time.Time {
+	return h.lastLoadedTime
 }
 
 // Auto-generated getters below`

--- a/cmd/protoc-gen-go-tableau-loader/hub.go
+++ b/cmd/protoc-gen-go-tableau-loader/hub.go
@@ -145,7 +145,7 @@ type Hub struct {
 func NewHub() *Hub {
 	return &Hub{
 		messagerMap:    MessagerMap{},
-		lastLoadedTime: time.Now(),
+		lastLoadedTime: time.Unix(0, 0),
 	}
 }
 


### PR DESCRIPTION
1. add a `GetLastLoadedTime` method for hub in cpp/go, which returns the time when `SetMessagerContainer` was last called (also the time when protoconf was last loaded).
2. fix a bug where string concatenation and format patterns are both used on `g_err_msg`.