### PR TITLE
fix(cpp/go):  invalid variable names of getters

### DIFF
--- a/cmd/protoc-gen-cpp-tableau-loader/helper/helper.go
+++ b/cmd/protoc-gen-cpp-tableau-loader/helper/helper.go
@@ -102,7 +102,8 @@ func AddMapKey(fd protoreflect.FieldDescriptor, keys []MapKey) []MapKey {
 	opts := fd.Options().(*descriptorpb.FieldOptions)
 	fdOpts := proto.GetExtension(opts, tableaupb.E_Field).(*tableaupb.FieldOptions)
 	name := strcase.ToSnake(strings.TrimSpace(fdOpts.GetKey()))
-	if name == "" {
+	name = escapeIdentifier(name)
+	if name == "" || name == "key" {
 		name = fmt.Sprintf("key%d", len(keys)+1)
 	} else {
 		for _, key := range keys {
@@ -113,7 +114,7 @@ func AddMapKey(fd protoreflect.FieldDescriptor, keys []MapKey) []MapKey {
 			}
 		}
 	}
-	keys = append(keys, MapKey{ParseCppType(fd.MapKey()), KeywordEscape(name)})
+	keys = append(keys, MapKey{ParseCppType(fd.MapKey()), name})
 	return keys
 }
 

--- a/cmd/protoc-gen-cpp-tableau-loader/helper/helper.go
+++ b/cmd/protoc-gen-cpp-tableau-loader/helper/helper.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/iancoleman/strcase"
 	"github.com/tableauio/tableau/proto/tableaupb"
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/proto"
@@ -101,15 +100,19 @@ type MapKey struct {
 func AddMapKey(fd protoreflect.FieldDescriptor, keys []MapKey) []MapKey {
 	opts := fd.Options().(*descriptorpb.FieldOptions)
 	fdOpts := proto.GetExtension(opts, tableaupb.E_Field).(*tableaupb.FieldOptions)
-	name := strcase.ToSnake(strings.TrimSpace(fdOpts.GetKey()))
+	name := fdOpts.GetKey()
+	if fd.MapValue().Kind() == protoreflect.MessageKind {
+		valueFd := fd.MapValue().Message().Fields().Get(0)
+		name = string(valueFd.Name())
+	}
 	name = escapeIdentifier(name)
-	if name == "" || name == "key" {
+	if name == "" {
 		name = fmt.Sprintf("key%d", len(keys)+1)
 	} else {
 		for _, key := range keys {
 			if key.Name == name {
 				// rewrite to avoid name confict
-				name = fmt.Sprintf("%s_key%d", name, len(keys)+1)
+				name = fmt.Sprintf("%s%d", name, len(keys)+1)
 				break
 			}
 		}

--- a/cmd/protoc-gen-cpp-tableau-loader/helper/keyword.go
+++ b/cmd/protoc-gen-cpp-tableau-loader/helper/keyword.go
@@ -1,8 +1,26 @@
 package helper
 
+import (
+	"strings"
+	"unicode"
+)
+
 var cppKeywords map[string]bool
 
-func KeywordEscape(str string) string {
+func escapeIdentifier(str string) string {
+	// Filter invalid runes
+	var result strings.Builder
+	for _, r := range str {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) || r == '_' {
+			result.WriteRune(r)
+		}
+	}
+	str = result.String()
+	// Cpp variables must not start with digits
+	if len(str) != 0 && unicode.IsDigit(rune(str[0])) {
+		str = "_" + str
+	}
+	// avoid cpp keywords
 	if _, ok := cppKeywords[str]; ok {
 		return str + "_"
 	}

--- a/cmd/protoc-gen-cpp-tableau-loader/helper/keyword.go
+++ b/cmd/protoc-gen-cpp-tableau-loader/helper/keyword.go
@@ -3,6 +3,8 @@ package helper
 import (
 	"strings"
 	"unicode"
+
+	"github.com/iancoleman/strcase"
 )
 
 var cppKeywords map[string]bool
@@ -16,11 +18,13 @@ func escapeIdentifier(str string) string {
 		}
 	}
 	str = result.String()
+	// To snake case
+	str = strcase.ToSnake(str)
 	// Cpp variables must not start with digits
 	if len(str) != 0 && unicode.IsDigit(rune(str[0])) {
 		str = "_" + str
 	}
-	// avoid cpp keywords
+	// Avoid cpp keywords
 	if _, ok := cppKeywords[str]; ok {
 		return str + "_"
 	}

--- a/cmd/protoc-gen-go-tableau-loader/helper/helper.go
+++ b/cmd/protoc-gen-go-tableau-loader/helper/helper.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/iancoleman/strcase"
 	"github.com/tableauio/tableau/proto/tableaupb"
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/proto"
@@ -96,15 +95,19 @@ type MapKey struct {
 func AddMapKey(file *protogen.File, fd protoreflect.FieldDescriptor, keys []MapKey) []MapKey {
 	opts := fd.Options().(*descriptorpb.FieldOptions)
 	fdOpts := proto.GetExtension(opts, tableaupb.E_Field).(*tableaupb.FieldOptions)
-	name := strcase.ToLowerCamel(strings.TrimSpace(fdOpts.GetKey()))
+	name := fdOpts.GetKey()
+	if fd.MapValue().Kind() == protoreflect.MessageKind {
+		valueFd := fd.MapValue().Message().Fields().Get(0)
+		name = string(valueFd.Name())
+	}
 	name = escapeIdentifier(name)
-	if name == "" || name == "key" {
+	if name == "" {
 		name = fmt.Sprintf("key%d", len(keys)+1)
 	} else {
 		for _, key := range keys {
 			if key.Name == name {
 				// rewrite to avoid name confict
-				name = fmt.Sprintf("%s_key%d", name, len(keys)+1)
+				name = fmt.Sprintf("%s%d", name, len(keys)+1)
 				break
 			}
 		}

--- a/cmd/protoc-gen-go-tableau-loader/helper/helper.go
+++ b/cmd/protoc-gen-go-tableau-loader/helper/helper.go
@@ -97,7 +97,8 @@ func AddMapKey(file *protogen.File, fd protoreflect.FieldDescriptor, keys []MapK
 	opts := fd.Options().(*descriptorpb.FieldOptions)
 	fdOpts := proto.GetExtension(opts, tableaupb.E_Field).(*tableaupb.FieldOptions)
 	name := strcase.ToLowerCamel(strings.TrimSpace(fdOpts.GetKey()))
-	if name == "" {
+	name = escapeIdentifier(name)
+	if name == "" || name == "key" {
 		name = fmt.Sprintf("key%d", len(keys)+1)
 	} else {
 		for _, key := range keys {
@@ -108,7 +109,7 @@ func AddMapKey(file *protogen.File, fd protoreflect.FieldDescriptor, keys []MapK
 			}
 		}
 	}
-	keys = append(keys, MapKey{ParseGoType(file, fd.MapKey()), KeywordEscape(name)})
+	keys = append(keys, MapKey{ParseGoType(file, fd.MapKey()), name})
 	return keys
 }
 

--- a/cmd/protoc-gen-go-tableau-loader/helper/keyword.go
+++ b/cmd/protoc-gen-go-tableau-loader/helper/keyword.go
@@ -1,8 +1,26 @@
 package helper
 
+import (
+	"strings"
+	"unicode"
+)
+
 var golangKeywords map[string]bool
 
-func KeywordEscape(str string) string {
+func escapeIdentifier(str string) string {
+	// Filter invalid runes
+	var result strings.Builder
+	for _, r := range str {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) || r == '_' {
+			result.WriteRune(r)
+		}
+	}
+	str = result.String()
+	// Go variables must not start with digits
+	if len(str) != 0 && unicode.IsDigit(rune(str[0])) {
+		str = "_" + str
+	}
+	// avoid go keywords
 	if _, ok := golangKeywords[str]; ok {
 		return str + "_"
 	}

--- a/cmd/protoc-gen-go-tableau-loader/helper/keyword.go
+++ b/cmd/protoc-gen-go-tableau-loader/helper/keyword.go
@@ -3,6 +3,8 @@ package helper
 import (
 	"strings"
 	"unicode"
+
+	"github.com/iancoleman/strcase"
 )
 
 var golangKeywords map[string]bool
@@ -16,11 +18,13 @@ func escapeIdentifier(str string) string {
 		}
 	}
 	str = result.String()
+	// To camel case
+	str = strcase.ToLowerCamel(str)
 	// Go variables must not start with digits
 	if len(str) != 0 && unicode.IsDigit(rune(str[0])) {
 		str = "_" + str
 	}
-	// avoid go keywords
+	// Avoid go keywords
 	if _, ok := golangKeywords[str]; ok {
 		return str + "_"
 	}


### PR DESCRIPTION
- close #47
Generated getters when custom names are used for yaml keys:
![image](https://github.com/user-attachments/assets/21c9fcc3-66a5-47d2-8063-70bf706ea7c7)
![image](https://github.com/user-attachments/assets/88e9a513-4861-47e7-9a12-d780a0f9dc53)
![image](https://github.com/user-attachments/assets/008d8cb3-8ee3-4022-89aa-b16996f6b9d8)

Generated getters when no custom name is used for yaml keys:
![image](https://github.com/user-attachments/assets/74097bd8-c729-40df-aff7-7155e84c6e95)
![image](https://github.com/user-attachments/assets/9d982136-dc61-4898-b498-5082734d5e16)
![image](https://github.com/user-attachments/assets/6e95cb50-314c-436e-8fdf-3e3d14203db1)
