### PR TITLE
fix(go): use correct struct name for getters when first char of message name not capitalized

### DIFF
--- a/cmd/protoc-gen-go-tableau-loader/helper/helper.go
+++ b/cmd/protoc-gen-go-tableau-loader/helper/helper.go
@@ -46,7 +46,7 @@ func ParseGoType(gen *protogen.Plugin, fd protoreflect.FieldDescriptor) string {
 		return "[]byte"
 	case protoreflect.MessageKind:
 		if file, ok := gen.FilesByPath[fd.Message().ParentFile().Path()]; ok {
-			message := findMessageByDescriptor(file.Messages, fd.Message())
+			message := FindMessageByDescriptor(file.Messages, fd.Message())
 			if message != nil {
 				return message.GoIdent.GoName
 			}
@@ -59,13 +59,13 @@ func ParseGoType(gen *protogen.Plugin, fd protoreflect.FieldDescriptor) string {
 	}
 }
 
-func findMessageByDescriptor(messages []*protogen.Message, desc protoreflect.MessageDescriptor) *protogen.Message {
+func FindMessageByDescriptor(messages []*protogen.Message, desc protoreflect.MessageDescriptor) *protogen.Message {
 	for _, message := range messages {
 		if message.Desc.FullName() == desc.FullName() {
 			return message
 		}
 		// Recursively search nested messages
-		if nestedMessage := findMessageByDescriptor(message.Messages, desc); nestedMessage != nil {
+		if nestedMessage := FindMessageByDescriptor(message.Messages, desc); nestedMessage != nil {
 			return nestedMessage
 		}
 	}

--- a/cmd/protoc-gen-go-tableau-loader/helper/helper.go
+++ b/cmd/protoc-gen-go-tableau-loader/helper/helper.go
@@ -47,7 +47,7 @@ func ParseGoType(gen *protogen.Plugin, fd protoreflect.FieldDescriptor) string {
 	case protoreflect.MessageKind:
 		var mapValueMessage *protogen.Message
 		for _, f := range gen.Files {
-			mapValueMessage = findMessageByDescriptor(f, fd.Message())
+			mapValueMessage = findMessageByDescriptor(f.Messages, fd.Message())
 			if mapValueMessage != nil {
 				break
 			}
@@ -63,26 +63,13 @@ func ParseGoType(gen *protogen.Plugin, fd protoreflect.FieldDescriptor) string {
 	}
 }
 
-func findMessageByDescriptor(file *protogen.File, desc protoreflect.MessageDescriptor) *protogen.Message {
-	for _, message := range file.Messages {
+func findMessageByDescriptor(messages []*protogen.Message, desc protoreflect.MessageDescriptor) *protogen.Message {
+	for _, message := range messages {
 		if message.Desc.FullName() == desc.FullName() {
 			return message
 		}
 		// Recursively search nested messages
-		if nestedMessage := findNestedMessageByDescriptor(message, desc); nestedMessage != nil {
-			return nestedMessage
-		}
-	}
-	return nil
-}
-
-func findNestedMessageByDescriptor(parent *protogen.Message, desc protoreflect.MessageDescriptor) *protogen.Message {
-	for _, nested := range parent.Messages {
-		if nested.Desc.FullName() == desc.FullName() {
-			return nested
-		}
-		// Recursively search nested messages
-		if nestedMessage := findNestedMessageByDescriptor(nested, desc); nestedMessage != nil {
+		if nestedMessage := findMessageByDescriptor(message.Messages, desc); nestedMessage != nil {
 			return nestedMessage
 		}
 	}

--- a/cmd/protoc-gen-go-tableau-loader/helper/helper.go
+++ b/cmd/protoc-gen-go-tableau-loader/helper/helper.go
@@ -45,17 +45,13 @@ func ParseGoType(gen *protogen.Plugin, fd protoreflect.FieldDescriptor) string {
 	case protoreflect.BytesKind:
 		return "[]byte"
 	case protoreflect.MessageKind:
-		var mapValueMessage *protogen.Message
-		for _, f := range gen.Files {
-			mapValueMessage = findMessageByDescriptor(f.Messages, fd.Message())
-			if mapValueMessage != nil {
-				break
+		if file, ok := gen.FilesByPath[fd.Message().ParentFile().Path()]; ok {
+			message := findMessageByDescriptor(file.Messages, fd.Message())
+			if message != nil {
+				return message.GoIdent.GoName
 			}
 		}
-		if mapValueMessage != nil {
-			return mapValueMessage.GoIdent.GoName
-		}
-		fallthrough
+		return fmt.Sprintf("<not found:%s>", fd.Message().FullName())
 	// case protoreflect.GroupKind:
 	// 	return "group"
 	default:

--- a/test/go-tableau-loader/gen.sh
+++ b/test/go-tableau-loader/gen.sh
@@ -11,16 +11,26 @@ TABLEAU_PROTO="./third_party/_submodules/tableau/proto"
 PLGUIN_DIR="./cmd/protoc-gen-go-tableau-loader"
 PROTOCONF_IN="./test/proto"
 PROTOCONF_OUT="./test/go-tableau-loader/protoconf"
+BASE_IN="./test/proto/base"
+BASE_OUT="./test/go-tableau-loader/base"
 LOADER_OUT="$PROTOCONF_OUT/loader"
 
 # remove old generated files
-rm -rfv "$PROTOCONF_OUT" "$LOADER_OUT"
-mkdir -p "$PROTOCONF_OUT" "$LOADER_OUT"
+rm -rfv "$PROTOCONF_OUT" "$LOADER_OUT" "$BASE_OUT"
+mkdir -p "$PROTOCONF_OUT" "$LOADER_OUT" "$BASE_OUT"
 
 # build
 cd "${PLGUIN_DIR}" && go build && cd -
 
 export PATH="${PLGUIN_DIR}:${PATH}"
+
+${PROTOC} \
+--go_out="$BASE_OUT" \
+--go_opt=paths=source_relative \
+--proto_path="$PROTOBUF_PROTO" \
+--proto_path="$TABLEAU_PROTO" \
+--proto_path="$BASE_IN" \
+"$BASE_IN"/*.proto
 
 ${PROTOC} \
 --go-tableau-loader_out="$LOADER_OUT" \
@@ -30,4 +40,5 @@ ${PROTOC} \
 --proto_path="$PROTOBUF_PROTO" \
 --proto_path="$TABLEAU_PROTO" \
 --proto_path="$PROTOCONF_IN" \
-"$PROTOCONF_IN"/*
+--proto_path="$BASE_IN" \
+"$PROTOCONF_IN"/*.proto

--- a/test/go-tableau-loader/main.go
+++ b/test/go-tableau-loader/main.go
@@ -17,9 +17,9 @@ func main() {
 		load.Paths(map[string]string{
 			"ItemConf": "../testdata/conf/ItemConf.json",
 		}))
-		load.Filter(func(name string) bool {
-			return true
-		})
+	load.Filter(func(name string) bool {
+		return true
+	})
 	if err != nil {
 		panic(err)
 	}
@@ -67,4 +67,5 @@ func main() {
 		}
 	}
 	fmt.Printf("specialItemName: %v\n", hub.GetHub().GetCustomItemConf().GetSpecialItemName())
+	fmt.Printf("HeroBaseConf: %v\n", hub.GetHub().GetHeroBaseConf().Data().GetHeroMap())
 }

--- a/test/go-tableau-loader/protoconf/loader/hero_conf.pc.go
+++ b/test/go-tableau-loader/protoconf/loader/hero_conf.pc.go
@@ -9,6 +9,7 @@ package loader
 import (
 	pair "github.com/tableauio/loader/pkg/pair"
 	treemap "github.com/tableauio/loader/pkg/treemap"
+	base "github.com/tableauio/loader/test/go-tableau-loader/base"
 	protoconf "github.com/tableauio/loader/test/go-tableau-loader/protoconf"
 	code "github.com/tableauio/loader/test/go-tableau-loader/protoconf/loader/code"
 	xerrors "github.com/tableauio/loader/test/go-tableau-loader/protoconf/loader/xerrors"
@@ -21,7 +22,7 @@ import (
 type HeroConf_Hero_Attr_OrderedMap = treemap.TreeMap[string, *protoconf.HeroConf_Hero_Attr]
 
 type HeroConf_Hero_OrderedMapValue = pair.Pair[*HeroConf_Hero_Attr_OrderedMap, *protoconf.HeroConf_Hero]
-type HeroConf_Hero_OrderedMap = treemap.TreeMap[string, HeroConf_Hero_OrderedMapValue]
+type HeroConf_Hero_OrderedMap = treemap.TreeMap[string, *HeroConf_Hero_OrderedMapValue]
 
 // HeroConf is a wrapper around protobuf message: protoconf.HeroConf.
 //
@@ -75,14 +76,14 @@ func (x *HeroConf) Messager() Messager {
 // AfterLoad runs after this messager is loaded.
 func (x *HeroConf) AfterLoad() error {
 	// OrderedMap init.
-	x.orderedMap = treemap.New[string, HeroConf_Hero_OrderedMapValue]()
+	x.orderedMap = treemap.New[string, *HeroConf_Hero_OrderedMapValue]()
 	for k1, v1 := range x.Data().GetHeroMap() {
 		map1 := x.orderedMap
-		map1.Put(k1, HeroConf_Hero_OrderedMapValue{
+		k1v := &HeroConf_Hero_OrderedMapValue{
 			First:  treemap.New[string, *protoconf.HeroConf_Hero_Attr](),
 			Second: v1,
-		})
-		k1v, _ := map1.Get(k1)
+		}
+		map1.Put(k1, k1v)
 		for k2, v2 := range v1.GetAttrMap() {
 			map2 := k1v.First
 			map2.Put(k2, v2)
@@ -140,8 +141,134 @@ func (x *HeroConf) GetOrderedMap1(name string) (*HeroConf_Hero_Attr_OrderedMap, 
 	}
 }
 
+// OrderedMap types.
+type HeroBaseConf_base_Item_OrderedMap = treemap.TreeMap[string, *base.Item]
+
+type HeroBaseConf_base_Hero_OrderedMapValue = pair.Pair[*HeroBaseConf_base_Item_OrderedMap, *base.Hero]
+type HeroBaseConf_base_Hero_OrderedMap = treemap.TreeMap[string, *HeroBaseConf_base_Hero_OrderedMapValue]
+
+// HeroBaseConf is a wrapper around protobuf message: protoconf.HeroBaseConf.
+//
+// It is designed for three goals:
+//
+//  1. Easy use: simple yet powerful accessers.
+//  2. Elegant API: concise and clean functions.
+//  3. Extensibility: Map, OrdererdMap, Index...
+type HeroBaseConf struct {
+	UnimplementedMessager
+	data       protoconf.HeroBaseConf
+	orderedMap *HeroBaseConf_base_Hero_OrderedMap
+}
+
+// Name returns the HeroBaseConf's message name.
+func (x *HeroBaseConf) Name() string {
+	if x != nil {
+		return string((&x.data).ProtoReflect().Descriptor().Name())
+	}
+	return ""
+}
+
+// Data returns the HeroBaseConf's inner message data.
+func (x *HeroBaseConf) Data() *protoconf.HeroBaseConf {
+	if x != nil {
+		return &x.data
+	}
+	return nil
+}
+
+// Load fills HeroBaseConf's inner message from file in the specified directory and format.
+func (x *HeroBaseConf) Load(dir string, format format.Format, options ...load.Option) error {
+	err := load.Load(x.Data(), dir, format, options...)
+	if err != nil {
+		return err
+	}
+	return x.AfterLoad()
+}
+
+// Store writes HeroBaseConf's inner message to file in the specified directory and format.
+// Available formats: JSON, Bin, and Text.
+func (x *HeroBaseConf) Store(dir string, format format.Format, options ...store.Option) error {
+	return store.Store(x.Data(), dir, format, options...)
+}
+
+// Messager is used to implement Checker interface.
+func (x *HeroBaseConf) Messager() Messager {
+	return x
+}
+
+// AfterLoad runs after this messager is loaded.
+func (x *HeroBaseConf) AfterLoad() error {
+	// OrderedMap init.
+	x.orderedMap = treemap.New[string, *HeroBaseConf_base_Hero_OrderedMapValue]()
+	for k1, v1 := range x.Data().GetHeroMap() {
+		map1 := x.orderedMap
+		k1v := &HeroBaseConf_base_Hero_OrderedMapValue{
+			First:  treemap.New[string, *base.Item](),
+			Second: v1,
+		}
+		map1.Put(k1, k1v)
+		for k2, v2 := range v1.GetItemMap() {
+			map2 := k1v.First
+			map2.Put(k2, v2)
+		}
+	}
+	return nil
+}
+
+// Get1 finds value in the 1-level map. It will return nil if
+// the deepest key is not found, otherwise return an error.
+func (x *HeroBaseConf) Get1(name string) (*base.Hero, error) {
+	d := x.Data().GetHeroMap()
+	if d == nil {
+		return nil, xerrors.Errorf(code.Nil, "HeroMap is nil")
+	}
+	if val, ok := d[name]; !ok {
+		return nil, xerrors.Errorf(code.NotFound, "name(%v) not found", name)
+	} else {
+		return val, nil
+	}
+}
+
+// Get2 finds value in the 2-level map. It will return nil if
+// the deepest key is not found, otherwise return an error.
+func (x *HeroBaseConf) Get2(name string, id string) (*base.Item, error) {
+	conf, err := x.Get1(name)
+	if err != nil {
+		return nil, err
+	}
+
+	d := conf.GetItemMap()
+	if d == nil {
+		return nil, xerrors.Errorf(code.Nil, "ItemMap is nil")
+	}
+	if val, ok := d[id]; !ok {
+		return nil, xerrors.Errorf(code.NotFound, "id(%v) not found", id)
+	} else {
+		return val, nil
+	}
+}
+
+// GetOrderedMap returns the 1-level ordered map.
+func (x *HeroBaseConf) GetOrderedMap() *HeroBaseConf_base_Hero_OrderedMap {
+	return x.orderedMap
+}
+
+// GetOrderedMap1 finds value in the 1-level ordered map. It will return nil if
+// the deepest key is not found, otherwise return an error.
+func (x *HeroBaseConf) GetOrderedMap1(name string) (*HeroBaseConf_base_Item_OrderedMap, error) {
+	conf := x.orderedMap
+	if val, ok := conf.Get(name); !ok {
+		return nil, xerrors.Errorf(code.NotFound, "name(%v) not found", name)
+	} else {
+		return val.First, nil
+	}
+}
+
 func init() {
 	Register(func() Messager {
 		return new(HeroConf)
+	})
+	Register(func() Messager {
+		return new(HeroBaseConf)
 	})
 }

--- a/test/go-tableau-loader/protoconf/loader/hero_conf.pc.go
+++ b/test/go-tableau-loader/protoconf/loader/hero_conf.pc.go
@@ -19,10 +19,10 @@ import (
 )
 
 // OrderedMap types.
-type HeroConf_Hero_Attr_OrderedMap = treemap.TreeMap[string, *protoconf.HeroConf_Hero_Attr]
+type ProtoconfHeroConfHeroAttrMap_OrderedMap = treemap.TreeMap[string, *protoconf.HeroConf_Hero_Attr]
 
-type HeroConf_Hero_OrderedMapValue = pair.Pair[*HeroConf_Hero_Attr_OrderedMap, *protoconf.HeroConf_Hero]
-type HeroConf_Hero_OrderedMap = treemap.TreeMap[string, *HeroConf_Hero_OrderedMapValue]
+type ProtoconfHeroConfHeroMap_OrderedMapValue = pair.Pair[*ProtoconfHeroConfHeroAttrMap_OrderedMap, *protoconf.HeroConf_Hero]
+type ProtoconfHeroConfHeroMap_OrderedMap = treemap.TreeMap[string, *ProtoconfHeroConfHeroMap_OrderedMapValue]
 
 // HeroConf is a wrapper around protobuf message: protoconf.HeroConf.
 //
@@ -34,7 +34,7 @@ type HeroConf_Hero_OrderedMap = treemap.TreeMap[string, *HeroConf_Hero_OrderedMa
 type HeroConf struct {
 	UnimplementedMessager
 	data       protoconf.HeroConf
-	orderedMap *HeroConf_Hero_OrderedMap
+	orderedMap *ProtoconfHeroConfHeroMap_OrderedMap
 }
 
 // Name returns the HeroConf's message name.
@@ -76,10 +76,10 @@ func (x *HeroConf) Messager() Messager {
 // AfterLoad runs after this messager is loaded.
 func (x *HeroConf) AfterLoad() error {
 	// OrderedMap init.
-	x.orderedMap = treemap.New[string, *HeroConf_Hero_OrderedMapValue]()
+	x.orderedMap = treemap.New[string, *ProtoconfHeroConfHeroMap_OrderedMapValue]()
 	for k1, v1 := range x.Data().GetHeroMap() {
 		map1 := x.orderedMap
-		k1v := &HeroConf_Hero_OrderedMapValue{
+		k1v := &ProtoconfHeroConfHeroMap_OrderedMapValue{
 			First:  treemap.New[string, *protoconf.HeroConf_Hero_Attr](),
 			Second: v1,
 		}
@@ -126,13 +126,13 @@ func (x *HeroConf) Get2(name string, title string) (*protoconf.HeroConf_Hero_Att
 }
 
 // GetOrderedMap returns the 1-level ordered map.
-func (x *HeroConf) GetOrderedMap() *HeroConf_Hero_OrderedMap {
+func (x *HeroConf) GetOrderedMap() *ProtoconfHeroConfHeroMap_OrderedMap {
 	return x.orderedMap
 }
 
 // GetOrderedMap1 finds value in the 1-level ordered map. It will return nil if
 // the deepest key is not found, otherwise return an error.
-func (x *HeroConf) GetOrderedMap1(name string) (*HeroConf_Hero_Attr_OrderedMap, error) {
+func (x *HeroConf) GetOrderedMap1(name string) (*ProtoconfHeroConfHeroAttrMap_OrderedMap, error) {
 	conf := x.orderedMap
 	if val, ok := conf.Get(name); !ok {
 		return nil, xerrors.Errorf(code.NotFound, "name(%v) not found", name)
@@ -142,10 +142,10 @@ func (x *HeroConf) GetOrderedMap1(name string) (*HeroConf_Hero_Attr_OrderedMap, 
 }
 
 // OrderedMap types.
-type HeroBaseConf_base_Item_OrderedMap = treemap.TreeMap[string, *base.Item]
+type BaseHeroItemMap_OrderedMap = treemap.TreeMap[string, *base.Item]
 
-type HeroBaseConf_base_Hero_OrderedMapValue = pair.Pair[*HeroBaseConf_base_Item_OrderedMap, *base.Hero]
-type HeroBaseConf_base_Hero_OrderedMap = treemap.TreeMap[string, *HeroBaseConf_base_Hero_OrderedMapValue]
+type ProtoconfHeroBaseConfHeroMap_OrderedMapValue = pair.Pair[*BaseHeroItemMap_OrderedMap, *base.Hero]
+type ProtoconfHeroBaseConfHeroMap_OrderedMap = treemap.TreeMap[string, *ProtoconfHeroBaseConfHeroMap_OrderedMapValue]
 
 // HeroBaseConf is a wrapper around protobuf message: protoconf.HeroBaseConf.
 //
@@ -157,7 +157,7 @@ type HeroBaseConf_base_Hero_OrderedMap = treemap.TreeMap[string, *HeroBaseConf_b
 type HeroBaseConf struct {
 	UnimplementedMessager
 	data       protoconf.HeroBaseConf
-	orderedMap *HeroBaseConf_base_Hero_OrderedMap
+	orderedMap *ProtoconfHeroBaseConfHeroMap_OrderedMap
 }
 
 // Name returns the HeroBaseConf's message name.
@@ -199,10 +199,10 @@ func (x *HeroBaseConf) Messager() Messager {
 // AfterLoad runs after this messager is loaded.
 func (x *HeroBaseConf) AfterLoad() error {
 	// OrderedMap init.
-	x.orderedMap = treemap.New[string, *HeroBaseConf_base_Hero_OrderedMapValue]()
+	x.orderedMap = treemap.New[string, *ProtoconfHeroBaseConfHeroMap_OrderedMapValue]()
 	for k1, v1 := range x.Data().GetHeroMap() {
 		map1 := x.orderedMap
-		k1v := &HeroBaseConf_base_Hero_OrderedMapValue{
+		k1v := &ProtoconfHeroBaseConfHeroMap_OrderedMapValue{
 			First:  treemap.New[string, *base.Item](),
 			Second: v1,
 		}
@@ -249,13 +249,13 @@ func (x *HeroBaseConf) Get2(name string, id string) (*base.Item, error) {
 }
 
 // GetOrderedMap returns the 1-level ordered map.
-func (x *HeroBaseConf) GetOrderedMap() *HeroBaseConf_base_Hero_OrderedMap {
+func (x *HeroBaseConf) GetOrderedMap() *ProtoconfHeroBaseConfHeroMap_OrderedMap {
 	return x.orderedMap
 }
 
 // GetOrderedMap1 finds value in the 1-level ordered map. It will return nil if
 // the deepest key is not found, otherwise return an error.
-func (x *HeroBaseConf) GetOrderedMap1(name string) (*HeroBaseConf_base_Item_OrderedMap, error) {
+func (x *HeroBaseConf) GetOrderedMap1(name string) (*BaseHeroItemMap_OrderedMap, error) {
 	conf := x.orderedMap
 	if val, ok := conf.Get(name); !ok {
 		return nil, xerrors.Errorf(code.NotFound, "name(%v) not found", name)

--- a/test/go-tableau-loader/protoconf/loader/hub.pc.go
+++ b/test/go-tableau-loader/protoconf/loader/hub.pc.go
@@ -193,6 +193,16 @@ func (h *Hub) GetHeroConf() *HeroConf {
 	return nil
 }
 
+func (h *Hub) GetHeroBaseConf() *HeroBaseConf {
+	msger := h.GetMessager("HeroBaseConf")
+	if msger != nil {
+		if conf, ok := msger.(*HeroBaseConf); ok {
+			return conf
+		}
+	}
+	return nil
+}
+
 func (h *Hub) GetItemConf() *ItemConf {
 	msger := h.GetMessager("ItemConf")
 	if msger != nil {

--- a/test/go-tableau-loader/protoconf/loader/item_conf.pc.go
+++ b/test/go-tableau-loader/protoconf/loader/item_conf.pc.go
@@ -17,7 +17,7 @@ import (
 )
 
 // OrderedMap types.
-type ItemConf_Item_OrderedMap = treemap.TreeMap[uint32, *protoconf.ItemConf_Item]
+type ProtoconfItemConfItemMap_OrderedMap = treemap.TreeMap[uint32, *protoconf.ItemConf_Item]
 
 // ItemConf is a wrapper around protobuf message: protoconf.ItemConf.
 //
@@ -29,7 +29,7 @@ type ItemConf_Item_OrderedMap = treemap.TreeMap[uint32, *protoconf.ItemConf_Item
 type ItemConf struct {
 	UnimplementedMessager
 	data       protoconf.ItemConf
-	orderedMap *ItemConf_Item_OrderedMap
+	orderedMap *ProtoconfItemConfItemMap_OrderedMap
 }
 
 // Name returns the ItemConf's message name.
@@ -94,7 +94,7 @@ func (x *ItemConf) Get1(id uint32) (*protoconf.ItemConf_Item, error) {
 }
 
 // GetOrderedMap returns the 1-level ordered map.
-func (x *ItemConf) GetOrderedMap() *ItemConf_Item_OrderedMap {
+func (x *ItemConf) GetOrderedMap() *ProtoconfItemConfItemMap_OrderedMap {
 	return x.orderedMap
 }
 

--- a/test/go-tableau-loader/protoconf/loader/test_conf.pc.go
+++ b/test/go-tableau-loader/protoconf/loader/test_conf.pc.go
@@ -18,16 +18,16 @@ import (
 )
 
 // OrderedMap types.
-type ActivityConf_int32_OrderedMap = treemap.TreeMap[uint32, int32]
+type ProtoconfSectionSectionRankMap_OrderedMap = treemap.TreeMap[uint32, int32]
 
-type ActivityConf_protoconf_Section_OrderedMapValue = pair.Pair[*ActivityConf_int32_OrderedMap, *protoconf.Section]
-type ActivityConf_protoconf_Section_OrderedMap = treemap.TreeMap[uint32, *ActivityConf_protoconf_Section_OrderedMapValue]
+type ProtoconfActivityConfActivityChapterSectionMap_OrderedMapValue = pair.Pair[*ProtoconfSectionSectionRankMap_OrderedMap, *protoconf.Section]
+type ProtoconfActivityConfActivityChapterSectionMap_OrderedMap = treemap.TreeMap[uint32, *ProtoconfActivityConfActivityChapterSectionMap_OrderedMapValue]
 
-type ActivityConf_Activity_Chapter_OrderedMapValue = pair.Pair[*ActivityConf_protoconf_Section_OrderedMap, *protoconf.ActivityConf_Activity_Chapter]
-type ActivityConf_Activity_Chapter_OrderedMap = treemap.TreeMap[uint32, *ActivityConf_Activity_Chapter_OrderedMapValue]
+type ProtoconfActivityConfActivityChapterMap_OrderedMapValue = pair.Pair[*ProtoconfActivityConfActivityChapterSectionMap_OrderedMap, *protoconf.ActivityConf_Activity_Chapter]
+type ProtoconfActivityConfActivityChapterMap_OrderedMap = treemap.TreeMap[uint32, *ProtoconfActivityConfActivityChapterMap_OrderedMapValue]
 
-type ActivityConf_Activity_OrderedMapValue = pair.Pair[*ActivityConf_Activity_Chapter_OrderedMap, *protoconf.ActivityConf_Activity]
-type ActivityConf_Activity_OrderedMap = treemap.TreeMap[uint64, *ActivityConf_Activity_OrderedMapValue]
+type ProtoconfActivityConfActivityMap_OrderedMapValue = pair.Pair[*ProtoconfActivityConfActivityChapterMap_OrderedMap, *protoconf.ActivityConf_Activity]
+type ProtoconfActivityConfActivityMap_OrderedMap = treemap.TreeMap[uint64, *ProtoconfActivityConfActivityMap_OrderedMapValue]
 
 // ActivityConf is a wrapper around protobuf message: protoconf.ActivityConf.
 //
@@ -39,7 +39,7 @@ type ActivityConf_Activity_OrderedMap = treemap.TreeMap[uint64, *ActivityConf_Ac
 type ActivityConf struct {
 	UnimplementedMessager
 	data       protoconf.ActivityConf
-	orderedMap *ActivityConf_Activity_OrderedMap
+	orderedMap *ProtoconfActivityConfActivityMap_OrderedMap
 }
 
 // Name returns the ActivityConf's message name.
@@ -81,24 +81,24 @@ func (x *ActivityConf) Messager() Messager {
 // AfterLoad runs after this messager is loaded.
 func (x *ActivityConf) AfterLoad() error {
 	// OrderedMap init.
-	x.orderedMap = treemap.New[uint64, *ActivityConf_Activity_OrderedMapValue]()
+	x.orderedMap = treemap.New[uint64, *ProtoconfActivityConfActivityMap_OrderedMapValue]()
 	for k1, v1 := range x.Data().GetActivityMap() {
 		map1 := x.orderedMap
-		k1v := &ActivityConf_Activity_OrderedMapValue{
-			First:  treemap.New[uint32, *ActivityConf_Activity_Chapter_OrderedMapValue](),
+		k1v := &ProtoconfActivityConfActivityMap_OrderedMapValue{
+			First:  treemap.New[uint32, *ProtoconfActivityConfActivityChapterMap_OrderedMapValue](),
 			Second: v1,
 		}
 		map1.Put(k1, k1v)
 		for k2, v2 := range v1.GetChapterMap() {
 			map2 := k1v.First
-			k2v := &ActivityConf_Activity_Chapter_OrderedMapValue{
-				First:  treemap.New[uint32, *ActivityConf_protoconf_Section_OrderedMapValue](),
+			k2v := &ProtoconfActivityConfActivityChapterMap_OrderedMapValue{
+				First:  treemap.New[uint32, *ProtoconfActivityConfActivityChapterSectionMap_OrderedMapValue](),
 				Second: v2,
 			}
 			map2.Put(k2, k2v)
 			for k3, v3 := range v2.GetSectionMap() {
 				map3 := k2v.First
-				k3v := &ActivityConf_protoconf_Section_OrderedMapValue{
+				k3v := &ProtoconfActivityConfActivityChapterSectionMap_OrderedMapValue{
 					First:  treemap.New[uint32, int32](),
 					Second: v3,
 				}
@@ -185,13 +185,13 @@ func (x *ActivityConf) Get4(activityId uint64, chapterId uint32, sectionId uint3
 }
 
 // GetOrderedMap returns the 1-level ordered map.
-func (x *ActivityConf) GetOrderedMap() *ActivityConf_Activity_OrderedMap {
+func (x *ActivityConf) GetOrderedMap() *ProtoconfActivityConfActivityMap_OrderedMap {
 	return x.orderedMap
 }
 
 // GetOrderedMap1 finds value in the 1-level ordered map. It will return nil if
 // the deepest key is not found, otherwise return an error.
-func (x *ActivityConf) GetOrderedMap1(activityId uint64) (*ActivityConf_Activity_Chapter_OrderedMap, error) {
+func (x *ActivityConf) GetOrderedMap1(activityId uint64) (*ProtoconfActivityConfActivityChapterMap_OrderedMap, error) {
 	conf := x.orderedMap
 	if val, ok := conf.Get(activityId); !ok {
 		return nil, xerrors.Errorf(code.NotFound, "activityId(%v) not found", activityId)
@@ -202,7 +202,7 @@ func (x *ActivityConf) GetOrderedMap1(activityId uint64) (*ActivityConf_Activity
 
 // GetOrderedMap2 finds value in the 2-level ordered map. It will return nil if
 // the deepest key is not found, otherwise return an error.
-func (x *ActivityConf) GetOrderedMap2(activityId uint64, chapterId uint32) (*ActivityConf_protoconf_Section_OrderedMap, error) {
+func (x *ActivityConf) GetOrderedMap2(activityId uint64, chapterId uint32) (*ProtoconfActivityConfActivityChapterSectionMap_OrderedMap, error) {
 	conf, err := x.GetOrderedMap1(activityId)
 	if err != nil {
 		return nil, err
@@ -216,7 +216,7 @@ func (x *ActivityConf) GetOrderedMap2(activityId uint64, chapterId uint32) (*Act
 
 // GetOrderedMap3 finds value in the 3-level ordered map. It will return nil if
 // the deepest key is not found, otherwise return an error.
-func (x *ActivityConf) GetOrderedMap3(activityId uint64, chapterId uint32, sectionId uint32) (*ActivityConf_int32_OrderedMap, error) {
+func (x *ActivityConf) GetOrderedMap3(activityId uint64, chapterId uint32, sectionId uint32) (*ProtoconfSectionSectionRankMap_OrderedMap, error) {
 	conf, err := x.GetOrderedMap2(activityId, chapterId)
 	if err != nil {
 		return nil, err

--- a/test/go-tableau-loader/protoconf/loader/test_conf.pc.go
+++ b/test/go-tableau-loader/protoconf/loader/test_conf.pc.go
@@ -20,14 +20,14 @@ import (
 // OrderedMap types.
 type ActivityConf_int32_OrderedMap = treemap.TreeMap[uint32, int32]
 
-type Uint32_Section_OrderedMapValue = pair.Pair[*ActivityConf_int32_OrderedMap, *protoconf.Section]
-type Uint32_Section_OrderedMap = treemap.TreeMap[uint32, Uint32_Section_OrderedMapValue]
+type ActivityConf_protoconf_Section_OrderedMapValue = pair.Pair[*ActivityConf_int32_OrderedMap, *protoconf.Section]
+type ActivityConf_protoconf_Section_OrderedMap = treemap.TreeMap[uint32, *ActivityConf_protoconf_Section_OrderedMapValue]
 
-type ActivityConf_Activity_Chapter_OrderedMapValue = pair.Pair[*Uint32_Section_OrderedMap, *protoconf.ActivityConf_Activity_Chapter]
-type ActivityConf_Activity_Chapter_OrderedMap = treemap.TreeMap[uint32, ActivityConf_Activity_Chapter_OrderedMapValue]
+type ActivityConf_Activity_Chapter_OrderedMapValue = pair.Pair[*ActivityConf_protoconf_Section_OrderedMap, *protoconf.ActivityConf_Activity_Chapter]
+type ActivityConf_Activity_Chapter_OrderedMap = treemap.TreeMap[uint32, *ActivityConf_Activity_Chapter_OrderedMapValue]
 
 type ActivityConf_Activity_OrderedMapValue = pair.Pair[*ActivityConf_Activity_Chapter_OrderedMap, *protoconf.ActivityConf_Activity]
-type ActivityConf_Activity_OrderedMap = treemap.TreeMap[uint64, ActivityConf_Activity_OrderedMapValue]
+type ActivityConf_Activity_OrderedMap = treemap.TreeMap[uint64, *ActivityConf_Activity_OrderedMapValue]
 
 // ActivityConf is a wrapper around protobuf message: protoconf.ActivityConf.
 //
@@ -81,28 +81,28 @@ func (x *ActivityConf) Messager() Messager {
 // AfterLoad runs after this messager is loaded.
 func (x *ActivityConf) AfterLoad() error {
 	// OrderedMap init.
-	x.orderedMap = treemap.New[uint64, ActivityConf_Activity_OrderedMapValue]()
+	x.orderedMap = treemap.New[uint64, *ActivityConf_Activity_OrderedMapValue]()
 	for k1, v1 := range x.Data().GetActivityMap() {
 		map1 := x.orderedMap
-		map1.Put(k1, ActivityConf_Activity_OrderedMapValue{
-			First:  treemap.New[uint32, ActivityConf_Activity_Chapter_OrderedMapValue](),
+		k1v := &ActivityConf_Activity_OrderedMapValue{
+			First:  treemap.New[uint32, *ActivityConf_Activity_Chapter_OrderedMapValue](),
 			Second: v1,
-		})
-		k1v, _ := map1.Get(k1)
+		}
+		map1.Put(k1, k1v)
 		for k2, v2 := range v1.GetChapterMap() {
 			map2 := k1v.First
-			map2.Put(k2, ActivityConf_Activity_Chapter_OrderedMapValue{
-				First:  treemap.New[uint32, Uint32_Section_OrderedMapValue](),
+			k2v := &ActivityConf_Activity_Chapter_OrderedMapValue{
+				First:  treemap.New[uint32, *ActivityConf_protoconf_Section_OrderedMapValue](),
 				Second: v2,
-			})
-			k2v, _ := map2.Get(k2)
+			}
+			map2.Put(k2, k2v)
 			for k3, v3 := range v2.GetSectionMap() {
 				map3 := k2v.First
-				map3.Put(k3, Uint32_Section_OrderedMapValue{
+				k3v := &ActivityConf_protoconf_Section_OrderedMapValue{
 					First:  treemap.New[uint32, int32](),
 					Second: v3,
-				})
-				k3v, _ := map3.Get(k3)
+				}
+				map3.Put(k3, k3v)
 				for k4, v4 := range v3.GetSectionRankMap() {
 					map4 := k3v.First
 					map4.Put(k4, v4)
@@ -202,7 +202,7 @@ func (x *ActivityConf) GetOrderedMap1(activityId uint64) (*ActivityConf_Activity
 
 // GetOrderedMap2 finds value in the 2-level ordered map. It will return nil if
 // the deepest key is not found, otherwise return an error.
-func (x *ActivityConf) GetOrderedMap2(activityId uint64, chapterId uint32) (*Uint32_Section_OrderedMap, error) {
+func (x *ActivityConf) GetOrderedMap2(activityId uint64, chapterId uint32) (*ActivityConf_protoconf_Section_OrderedMap, error) {
 	conf, err := x.GetOrderedMap1(activityId)
 	if err != nil {
 		return nil, err

--- a/test/proto/base/base.proto
+++ b/test/proto/base/base.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package base;
+
+option go_package = "github.com/tableauio/loader/test/go-tableau-loader/base";
+
+import "tableau/protobuf/tableau.proto";
+
+message Item {
+  uint32 id = 1 [(tableau.field) = { name: "ID" }];
+  int32 num = 2 [(tableau.field) = { name: "Num" }];
+}
+
+message Hero {
+  string name = 1 [(tableau.field) = { name: "Name" }];
+  map<string, Item> item_map = 2 [(tableau.field) = { key: "Item" layout: LAYOUT_VERTICAL }];
+}

--- a/test/proto/hero_conf.proto
+++ b/test/proto/hero_conf.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package protoconf;
 
 import "tableau/protobuf/tableau.proto";
+import "base.proto";
 
 option go_package = "github.com/tableauio/loader/test/go-tableau-loader/protoconf";
 option (tableau.workbook) = {
@@ -15,14 +16,21 @@ message HeroConf {
     ordered_map: true
     index: "Title"
   };
-  map<string, Hero> hero_map = 1 [(tableau.field) = {key:"Name" layout:LAYOUT_VERTICAL}];
+  map<string, Hero> hero_map = 1 [(tableau.field) = { key: "Name" layout: LAYOUT_VERTICAL }];
   message Hero {
-    string name = 1 [(tableau.field) = {name:"Name"}];
-    map<string, Attr> attr_map = 2 [(tableau.field) = {key:"Title" layout:LAYOUT_VERTICAL}];
+    string name = 1 [(tableau.field) = { name: "Name" }];
+    map<string, Attr> attr_map = 2 [(tableau.field) = { key: "Title" layout: LAYOUT_VERTICAL }];
     message Attr {
-      string title = 1 [(tableau.field) = {name:"Title"}];
-      string attr = 2 [(tableau.field) = {name:"Attr"}];
+      string title = 1 [(tableau.field) = { name: "Title" }];
+      string attr = 2 [(tableau.field) = { name: "Attr" }];
     }
   }
 }
 
+message HeroBaseConf {
+  option (tableau.worksheet) = {
+    name: "HeroBaseConf"
+    ordered_map: true
+  };
+  map<string, base.Hero> hero_map = 1 [(tableau.field) = { key: "Name" layout: LAYOUT_VERTICAL }];
+}

--- a/test/testdata/conf/HeroBaseConf.json
+++ b/test/testdata/conf/HeroBaseConf.json
@@ -1,0 +1,30 @@
+{
+    "heroMap": {
+        "venus": {
+            "name": "venus",
+            "itemMap": {
+                "1": {
+                    "id": 1,
+                    "name": "apple"
+                },
+                "2": {
+                    "id": 2,
+                    "name": "orange"
+                }
+            }
+        },
+        "zeus": {
+            "name": "zeus",
+            "itemMap": {
+                "3": {
+                    "id": 3,
+                    "name": "banana"
+                },
+                "4": {
+                    "id": 4,
+                    "name": "mango"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
1. when a nesting message name is not capitalized, the struct name of generate code is not correct, for example:
```proto
message RewardConf{
  map<uint32, rewardItem> reward_item_map = 1;
  message rewardItem{
    uint32 id = 1;
    ...
  }
}
```
Generated `pb.go`:
```go
type RewardConfRewardItem struct {
  state         protoimpl.MessageState
  sizeCache     protoimpl.SizeCache
  unknownFields protoimpl.UnknownFields
  ...
}
```
Generated `pc.go`:
```go
func (x *RewardConf) Get1(id uint32) (*protoconf.RewardConf_RewardItem, error) { // undefined protoconf.RewardConf_RewardItem
  ...
}
```
- close #37
2. support predefined map from another package (See `HeroBaseConf`)
3. pretty name for ordered map types (See `HeroBaseConf`)