### PR TITLE
go: allow calling Name() when messager is nil

### DIFF
--- a/cmd/protoc-gen-go-tableau-loader/messager.go
+++ b/cmd/protoc-gen-go-tableau-loader/messager.go
@@ -112,10 +112,7 @@ func genMessage(gen *protogen.Plugin, g *protogen.GeneratedFile, message *protog
 	// messager methods
 	g.P("// Name returns the ", messagerName, "'s message name.")
 	g.P("func (x *", messagerName, ") Name() string {")
-	g.P("if x != nil {")
-	g.P("return string(x.data.ProtoReflect().Descriptor().Name())")
-	g.P("}")
-	g.P(`return ""`)
+	g.P("return string((*", message.GoIdent, ")(nil).ProtoReflect().Descriptor().Name())")
 	g.P("}")
 	g.P()
 

--- a/test/go-tableau-loader/protoconf/loader/hero_conf.pc.go
+++ b/test/go-tableau-loader/protoconf/loader/hero_conf.pc.go
@@ -38,10 +38,7 @@ type HeroConf struct {
 
 // Name returns the HeroConf's message name.
 func (x *HeroConf) Name() string {
-	if x != nil {
-		return string(x.data.ProtoReflect().Descriptor().Name())
-	}
-	return ""
+	return string((*protoconf.HeroConf)(nil).ProtoReflect().Descriptor().Name())
 }
 
 // Data returns the HeroConf's inner message data.
@@ -179,10 +176,7 @@ type HeroBaseConf struct {
 
 // Name returns the HeroBaseConf's message name.
 func (x *HeroBaseConf) Name() string {
-	if x != nil {
-		return string(x.data.ProtoReflect().Descriptor().Name())
-	}
-	return ""
+	return string((*protoconf.HeroBaseConf)(nil).ProtoReflect().Descriptor().Name())
 }
 
 // Data returns the HeroBaseConf's inner message data.

--- a/test/go-tableau-loader/protoconf/loader/item_conf.pc.go
+++ b/test/go-tableau-loader/protoconf/loader/item_conf.pc.go
@@ -87,10 +87,7 @@ type ItemConf struct {
 
 // Name returns the ItemConf's message name.
 func (x *ItemConf) Name() string {
-	if x != nil {
-		return string(x.data.ProtoReflect().Descriptor().Name())
-	}
-	return ""
+	return string((*protoconf.ItemConf)(nil).ProtoReflect().Descriptor().Name())
 }
 
 // Data returns the ItemConf's inner message data.

--- a/test/go-tableau-loader/protoconf/loader/patch_conf.pc.go
+++ b/test/go-tableau-loader/protoconf/loader/patch_conf.pc.go
@@ -30,10 +30,7 @@ type PatchReplaceConf struct {
 
 // Name returns the PatchReplaceConf's message name.
 func (x *PatchReplaceConf) Name() string {
-	if x != nil {
-		return string(x.data.ProtoReflect().Descriptor().Name())
-	}
-	return ""
+	return string((*protoconf.PatchReplaceConf)(nil).ProtoReflect().Descriptor().Name())
 }
 
 // Data returns the PatchReplaceConf's inner message data.
@@ -99,10 +96,7 @@ type PatchMergeConf struct {
 
 // Name returns the PatchMergeConf's message name.
 func (x *PatchMergeConf) Name() string {
-	if x != nil {
-		return string(x.data.ProtoReflect().Descriptor().Name())
-	}
-	return ""
+	return string((*protoconf.PatchMergeConf)(nil).ProtoReflect().Descriptor().Name())
 }
 
 // Data returns the PatchMergeConf's inner message data.
@@ -179,10 +173,7 @@ type RecursivePatchConf struct {
 
 // Name returns the RecursivePatchConf's message name.
 func (x *RecursivePatchConf) Name() string {
-	if x != nil {
-		return string(x.data.ProtoReflect().Descriptor().Name())
-	}
-	return ""
+	return string((*protoconf.RecursivePatchConf)(nil).ProtoReflect().Descriptor().Name())
 }
 
 // Data returns the RecursivePatchConf's inner message data.

--- a/test/go-tableau-loader/protoconf/loader/test_conf.pc.go
+++ b/test/go-tableau-loader/protoconf/loader/test_conf.pc.go
@@ -63,10 +63,7 @@ type ActivityConf struct {
 
 // Name returns the ActivityConf's message name.
 func (x *ActivityConf) Name() string {
-	if x != nil {
-		return string(x.data.ProtoReflect().Descriptor().Name())
-	}
-	return ""
+	return string((*protoconf.ActivityConf)(nil).ProtoReflect().Descriptor().Name())
 }
 
 // Data returns the ActivityConf's inner message data.
@@ -398,10 +395,7 @@ type ChapterConf struct {
 
 // Name returns the ChapterConf's message name.
 func (x *ChapterConf) Name() string {
-	if x != nil {
-		return string(x.data.ProtoReflect().Descriptor().Name())
-	}
-	return ""
+	return string((*protoconf.ChapterConf)(nil).ProtoReflect().Descriptor().Name())
 }
 
 // Data returns the ChapterConf's inner message data.
@@ -478,10 +472,7 @@ type ThemeConf struct {
 
 // Name returns the ThemeConf's message name.
 func (x *ThemeConf) Name() string {
-	if x != nil {
-		return string(x.data.ProtoReflect().Descriptor().Name())
-	}
-	return ""
+	return string((*protoconf.ThemeConf)(nil).ProtoReflect().Descriptor().Name())
 }
 
 // Data returns the ThemeConf's inner message data.
@@ -591,10 +582,7 @@ type TaskConf struct {
 
 // Name returns the TaskConf's message name.
 func (x *TaskConf) Name() string {
-	if x != nil {
-		return string(x.data.ProtoReflect().Descriptor().Name())
-	}
-	return ""
+	return string((*protoconf.TaskConf)(nil).ProtoReflect().Descriptor().Name())
 }
 
 // Data returns the TaskConf's inner message data.


### PR DESCRIPTION
Method `Name()` of class `Messager` is static in cpp loader, so access to its name is allowed without a messager instance. We should keep same logic in go.