### PR TITLE
feat(BREAKING)!: flatten index key as finder arguments

### DIFF
--- a/cmd/protoc-gen-cpp-tableau-loader/index.go
+++ b/cmd/protoc-gen-cpp-tableau-loader/index.go
@@ -26,9 +26,9 @@ func genHppIndexFinders(g *protogen.GeneratedFile, descriptor *index.IndexDescri
 				g.P(helper.Indent(1), "// Finds the index (", index.Index, ") to value (", vectorType, ") hash map.")
 				g.P(helper.Indent(1), "// One key may correspond to multiple values, which are contained by a vector.")
 				g.P(helper.Indent(1), "const ", mapType, "& Find", index.Name(), "Map() const;")
-				g.P(helper.Indent(1), "// Finds a vector of all values of the given key(s).")
+				g.P(helper.Indent(1), "// Finds a vector of all values of the given key.")
 				g.P(helper.Indent(1), "const ", vectorType, "* Find", index.Name(), "(", helper.ToConstRefType(keyType), " ", helper.ParseIndexFieldNameAsFuncParam(field.FD), ") const;")
-				g.P(helper.Indent(1), "// Finds the first value of the given key(s).")
+				g.P(helper.Indent(1), "// Finds the first value of the given key.")
 				g.P(helper.Indent(1), "const ", helper.ParseCppClassType(index.MD), "* FindFirst", index.Name(), "(", helper.ToConstRefType(keyType), " ", helper.ParseIndexFieldNameAsFuncParam(field.FD), ") const;")
 				g.P()
 
@@ -86,9 +86,9 @@ func genHppIndexFinders(g *protogen.GeneratedFile, descriptor *index.IndexDescri
 				g.P(helper.Indent(1), "// Finds the index (", index.Index, ") to value (", vectorType, ") hash map.")
 				g.P(helper.Indent(1), "// One key may correspond to multiple values, which are contained by a vector.")
 				g.P(helper.Indent(1), "const ", mapType, "& Find", index.Name(), "Map() const;")
-				g.P(helper.Indent(1), "// Finds a vector of all values of the given key.")
+				g.P(helper.Indent(1), "// Finds a vector of all values of the given keys.")
 				g.P(helper.Indent(1), "const ", vectorType, "* Find", index.Name(), "(", helper.GenGetParams(keys), ") const;")
-				g.P(helper.Indent(1), "// Finds the first value of the given key.")
+				g.P(helper.Indent(1), "// Finds the first value of the given keys.")
 				g.P(helper.Indent(1), "const ", helper.ParseCppClassType(index.MD), "* FindFirst", index.Name(), "(", helper.GenGetParams(keys), ") const;")
 				g.P()
 

--- a/cmd/protoc-gen-cpp-tableau-loader/index.go
+++ b/cmd/protoc-gen-cpp-tableau-loader/index.go
@@ -47,9 +47,15 @@ func genHppIndexFinders(g *protogen.GeneratedFile, descriptor *index.IndexDescri
 
 				// generate key struct
 				g.P(helper.Indent(1), "struct ", keyType, " {")
+				var keys []helper.MapKey
 				equality := ""
 				for i, field := range index.ColFields {
-					g.P(helper.Indent(2), helper.ParseCppType(field.FD), " ", helper.ParseIndexFieldNameAsKeyStructFieldName(field.FD), ";")
+					typ := helper.ParseCppType(field.FD)
+					keys = append(keys, helper.MapKey{
+						Type: typ,
+						Name: helper.ParseIndexFieldNameAsFuncParam(field.FD),
+					})
+					g.P(helper.Indent(2), typ, " ", helper.ParseIndexFieldNameAsKeyStructFieldName(field.FD), ";")
 					equality += helper.ParseIndexFieldNameAsKeyStructFieldName(field.FD) + " == other." + helper.ParseIndexFieldNameAsKeyStructFieldName(field.FD)
 					if i != len(index.ColFields)-1 {
 						equality += " && "
@@ -81,9 +87,9 @@ func genHppIndexFinders(g *protogen.GeneratedFile, descriptor *index.IndexDescri
 				g.P(helper.Indent(1), "// One key may correspond to multiple values, which are contained by a vector.")
 				g.P(helper.Indent(1), "const ", mapType, "& Find", index.Name(), "() const;")
 				g.P(helper.Indent(1), "// Finds a vector of all values of the given key.")
-				g.P(helper.Indent(1), "const ", vectorType, "* Find", index.Name(), "(const ", keyType, "& key) const;")
+				g.P(helper.Indent(1), "const ", vectorType, "* Find", index.Name(), "(", helper.GenGetParams(keys), ") const;")
 				g.P(helper.Indent(1), "// Finds the first value of the given key.")
-				g.P(helper.Indent(1), "const ", helper.ParseCppClassType(index.MD), "* FindFirst", index.Name(), "(const ", keyType, "& key) const;")
+				g.P(helper.Indent(1), "const ", helper.ParseCppClassType(index.MD), "* FindFirst", index.Name(), "(", helper.GenGetParams(keys), ") const;")
 				g.P()
 
 				g.P(" private:")
@@ -251,20 +257,20 @@ func genCppIndexFinders(g *protogen.GeneratedFile, descriptor *index.IndexDescri
 			g.P("const ", messagerName, "::", mapType, "& ", messagerName, "::Find", index.Name(), "() const { return ", indexContainerName, " ;}")
 			g.P()
 
-			var keyType, keyName string
-			if len(index.ColFields) == 1 {
-				// single-column index
-				field := index.ColFields[0] // just take first field
-				keyType = helper.ParseCppType(field.FD)
-				keyName = helper.ParseIndexFieldNameAsFuncParam(field.FD)
-			} else {
-				// multi-column index
-				keyType = fmt.Sprintf("const Index_%sKey&", index.Name())
-				keyName = "key"
+			var keys []helper.MapKey
+			for _, field := range index.ColFields {
+				keys = append(keys, helper.MapKey{
+					Type: helper.ParseCppType(field.FD),
+					Name: helper.ParseIndexFieldNameAsFuncParam(field.FD),
+				})
 			}
 
-			g.P("const ", messagerName, "::", vectorType, "* ", messagerName, "::Find", index.Name(), "(", helper.ToConstRefType(keyType), " ", keyName, ") const {")
-			g.P(helper.Indent(1), "auto iter = ", indexContainerName, ".find(", keyName, ");")
+			g.P("const ", messagerName, "::", vectorType, "* ", messagerName, "::Find", index.Name(), "(", helper.GenGetParams(keys), ") const {")
+			if len(index.ColFields) == 1 {
+				g.P(helper.Indent(1), "auto iter = ", indexContainerName, ".find(", helper.GenGetArguments(keys), ");")
+			} else {
+				g.P(helper.Indent(1), "auto iter = ", indexContainerName, ".find({", helper.GenGetArguments(keys), "});")
+			}
 			g.P(helper.Indent(1), "if (iter == ", indexContainerName, ".end()) {")
 			g.P(helper.Indent(2), "return nullptr;")
 			g.P(helper.Indent(1), "}")
@@ -272,8 +278,8 @@ func genCppIndexFinders(g *protogen.GeneratedFile, descriptor *index.IndexDescri
 			g.P("}")
 			g.P()
 
-			g.P("const ", helper.ParseCppClassType(index.MD), "* ", messagerName, "::FindFirst", index.Name(), "(", helper.ToConstRefType(keyType), " ", keyName, ") const {")
-			g.P(helper.Indent(1), "auto conf = Find", index.Name(), "(", keyName, ");")
+			g.P("const ", helper.ParseCppClassType(index.MD), "* ", messagerName, "::FindFirst", index.Name(), "(", helper.GenGetParams(keys), ") const {")
+			g.P(helper.Indent(1), "auto conf = Find", index.Name(), "(", helper.GenGetArguments(keys), ");")
 			g.P(helper.Indent(1), "if (conf == nullptr || conf->empty()) {")
 			g.P(helper.Indent(2), "return nullptr;")
 			g.P(helper.Indent(1), "}")

--- a/cmd/protoc-gen-cpp-tableau-loader/index.go
+++ b/cmd/protoc-gen-cpp-tableau-loader/index.go
@@ -25,10 +25,10 @@ func genHppIndexFinders(g *protogen.GeneratedFile, descriptor *index.IndexDescri
 				g.P(helper.Indent(1), "using ", mapType, " = std::unordered_map<", keyType, ", ", vectorType, ">;")
 				g.P(helper.Indent(1), "// Finds the index (", index.Index, ") to value (", vectorType, ") hash map.")
 				g.P(helper.Indent(1), "// One key may correspond to multiple values, which are contained by a vector.")
-				g.P(helper.Indent(1), "const ", mapType, "& Find", index.Name(), "() const;")
-				g.P(helper.Indent(1), "// Finds a vector of all values of the given key.")
+				g.P(helper.Indent(1), "const ", mapType, "& Find", index.Name(), "Map() const;")
+				g.P(helper.Indent(1), "// Finds a vector of all values of the given key(s).")
 				g.P(helper.Indent(1), "const ", vectorType, "* Find", index.Name(), "(", helper.ToConstRefType(keyType), " ", helper.ParseIndexFieldNameAsFuncParam(field.FD), ") const;")
-				g.P(helper.Indent(1), "// Finds the first value of the given key.")
+				g.P(helper.Indent(1), "// Finds the first value of the given key(s).")
 				g.P(helper.Indent(1), "const ", helper.ParseCppClassType(index.MD), "* FindFirst", index.Name(), "(", helper.ToConstRefType(keyType), " ", helper.ParseIndexFieldNameAsFuncParam(field.FD), ") const;")
 				g.P()
 
@@ -85,7 +85,7 @@ func genHppIndexFinders(g *protogen.GeneratedFile, descriptor *index.IndexDescri
 				g.P(helper.Indent(1), "using ", mapType, " = std::unordered_map<", keyType, ", ", vectorType, ", ", keyHasherType, ">;")
 				g.P(helper.Indent(1), "// Finds the index (", index.Index, ") to value (", vectorType, ") hash map.")
 				g.P(helper.Indent(1), "// One key may correspond to multiple values, which are contained by a vector.")
-				g.P(helper.Indent(1), "const ", mapType, "& Find", index.Name(), "() const;")
+				g.P(helper.Indent(1), "const ", mapType, "& Find", index.Name(), "Map() const;")
 				g.P(helper.Indent(1), "// Finds a vector of all values of the given key.")
 				g.P(helper.Indent(1), "const ", vectorType, "* Find", index.Name(), "(", helper.GenGetParams(keys), ") const;")
 				g.P(helper.Indent(1), "// Finds the first value of the given key.")
@@ -254,7 +254,7 @@ func genCppIndexFinders(g *protogen.GeneratedFile, descriptor *index.IndexDescri
 			indexContainerName := "index_" + strcase.ToSnake(index.Name()) + "_map_"
 
 			g.P("// Index: ", index.Index)
-			g.P("const ", messagerName, "::", mapType, "& ", messagerName, "::Find", index.Name(), "() const { return ", indexContainerName, " ;}")
+			g.P("const ", messagerName, "::", mapType, "& ", messagerName, "::Find", index.Name(), "Map() const { return ", indexContainerName, " ;}")
 			g.P()
 
 			var keys []helper.MapKey

--- a/cmd/protoc-gen-go-tableau-loader/helper/helper.go
+++ b/cmd/protoc-gen-go-tableau-loader/helper/helper.go
@@ -42,7 +42,7 @@ func ParseIndexFieldNameAsFuncParam(gen *protogen.Plugin, fd protoreflect.FieldD
 
 // ParseGoType converts a FieldDescriptor to its Go type.
 // returns string if fd is scalar type, and protogen.GoIdent if fd is enum or message type.
-func ParseGoType(gen *protogen.Plugin, fd protoreflect.FieldDescriptor) any {
+func ParseGoType(gen *protogen.Plugin, g *protogen.GeneratedFile, fd protoreflect.FieldDescriptor) string {
 	switch fd.Kind() {
 	case protoreflect.BoolKind:
 		return "bool"
@@ -63,9 +63,9 @@ func ParseGoType(gen *protogen.Plugin, fd protoreflect.FieldDescriptor) any {
 	case protoreflect.BytesKind:
 		return "[]byte"
 	case protoreflect.EnumKind:
-		return FindEnumGoIdent(gen, fd.Enum())
+		return g.QualifiedGoIdent(FindEnumGoIdent(gen, fd.Enum()))
 	case protoreflect.MessageKind:
-		return FindMessageGoIdent(gen, fd.Message())
+		return g.QualifiedGoIdent(FindMessageGoIdent(gen, fd.Message()))
 	// case protoreflect.GroupKind:
 	// 	return "group"
 	default:

--- a/cmd/protoc-gen-go-tableau-loader/messager.go
+++ b/cmd/protoc-gen-go-tableau-loader/messager.go
@@ -264,16 +264,9 @@ func getNextLevelMapFD(fd protoreflect.FieldDescriptor) protoreflect.FieldDescri
 }
 
 func parseMapValueType(gen *protogen.Plugin, g *protogen.GeneratedFile, fd protoreflect.FieldDescriptor) string {
-	valueType := helper.ParseGoType(gen, fd.MapValue())
-	var valueTypeStr string
-	switch valueType := valueType.(type) {
-	case string:
-		valueTypeStr = valueType
-	case protogen.GoIdent:
-		valueTypeStr = g.QualifiedGoIdent(valueType)
-	}
+	valueType := helper.ParseGoType(gen, g, fd.MapValue())
 	if fd.MapValue().Kind() == protoreflect.MessageKind {
-		return "*" + valueTypeStr
+		return "*" + valueType
 	}
-	return valueTypeStr
+	return valueType
 }

--- a/test/cpp-tableau-loader/src/main.cpp
+++ b/test/cpp-tableau-loader/src/main.cpp
@@ -156,8 +156,7 @@ int main() {
   // std::cout << "item1: " << item_mgr->Data().DebugString() << std::endl;
 
   ATOM_DEBUG("-----Index: multi-column index test");
-  tableau::ItemConf::Index_AwardItemKey key{1, "apple"};
-  auto item = item_mgr->FindFirstAwardItem(key);
+  auto item = item_mgr->FindFirstAwardItem(1, "apple");
   if (!item) {
     ATOM_ERROR("ItemConf FindFirstAwardItem failed!");
     return 1;

--- a/test/cpp-tableau-loader/src/protoconf/item_conf.pc.cc
+++ b/test/cpp-tableau-loader/src/protoconf/item_conf.pc.cc
@@ -202,16 +202,16 @@ const protoconf::ItemConf::Item* ItemConf::FindFirstItemExtInfo(protoconf::Fruit
 // Index: (ID,Name)<Type,UseEffectType>@AwardItem
 const ItemConf::Index_AwardItemMap& ItemConf::FindAwardItem() const { return index_award_item_map_ ;}
 
-const ItemConf::Index_AwardItemVector* ItemConf::FindAwardItem(const Index_AwardItemKey& key) const {
-  auto iter = index_award_item_map_.find(key);
+const ItemConf::Index_AwardItemVector* ItemConf::FindAwardItem(uint32_t id, const std::string& name) const {
+  auto iter = index_award_item_map_.find({id, name});
   if (iter == index_award_item_map_.end()) {
     return nullptr;
   }
   return &iter->second;
 }
 
-const protoconf::ItemConf::Item* ItemConf::FindFirstAwardItem(const Index_AwardItemKey& key) const {
-  auto conf = FindAwardItem(key);
+const protoconf::ItemConf::Item* ItemConf::FindFirstAwardItem(uint32_t id, const std::string& name) const {
+  auto conf = FindAwardItem(id, name);
   if (conf == nullptr || conf->empty()) {
     return nullptr;
   }
@@ -221,16 +221,16 @@ const protoconf::ItemConf::Item* ItemConf::FindFirstAwardItem(const Index_AwardI
 // Index: (ID,Type,Param,ExtType)@SpecialItem
 const ItemConf::Index_SpecialItemMap& ItemConf::FindSpecialItem() const { return index_special_item_map_ ;}
 
-const ItemConf::Index_SpecialItemVector* ItemConf::FindSpecialItem(const Index_SpecialItemKey& key) const {
-  auto iter = index_special_item_map_.find(key);
+const ItemConf::Index_SpecialItemVector* ItemConf::FindSpecialItem(uint32_t id, protoconf::FruitType type, int32_t param, protoconf::FruitType ext_type) const {
+  auto iter = index_special_item_map_.find({id, type, param, ext_type});
   if (iter == index_special_item_map_.end()) {
     return nullptr;
   }
   return &iter->second;
 }
 
-const protoconf::ItemConf::Item* ItemConf::FindFirstSpecialItem(const Index_SpecialItemKey& key) const {
-  auto conf = FindSpecialItem(key);
+const protoconf::ItemConf::Item* ItemConf::FindFirstSpecialItem(uint32_t id, protoconf::FruitType type, int32_t param, protoconf::FruitType ext_type) const {
+  auto conf = FindSpecialItem(id, type, param, ext_type);
   if (conf == nullptr || conf->empty()) {
     return nullptr;
   }

--- a/test/cpp-tableau-loader/src/protoconf/item_conf.pc.cc
+++ b/test/cpp-tableau-loader/src/protoconf/item_conf.pc.cc
@@ -124,7 +124,7 @@ const ItemConf::Item_OrderedMap* ItemConf::GetOrderedMap() const {
 }
 
 // Index: Type
-const ItemConf::Index_ItemMap& ItemConf::FindItem() const { return index_item_map_ ;}
+const ItemConf::Index_ItemMap& ItemConf::FindItemMap() const { return index_item_map_ ;}
 
 const ItemConf::Index_ItemVector* ItemConf::FindItem(protoconf::FruitType type) const {
   auto iter = index_item_map_.find(type);
@@ -143,7 +143,7 @@ const protoconf::ItemConf::Item* ItemConf::FindFirstItem(protoconf::FruitType ty
 }
 
 // Index: Param<ID>@ItemInfo
-const ItemConf::Index_ItemInfoMap& ItemConf::FindItemInfo() const { return index_item_info_map_ ;}
+const ItemConf::Index_ItemInfoMap& ItemConf::FindItemInfoMap() const { return index_item_info_map_ ;}
 
 const ItemConf::Index_ItemInfoVector* ItemConf::FindItemInfo(int32_t param) const {
   auto iter = index_item_info_map_.find(param);
@@ -162,7 +162,7 @@ const protoconf::ItemConf::Item* ItemConf::FindFirstItemInfo(int32_t param) cons
 }
 
 // Index: Default@ItemDefaultInfo
-const ItemConf::Index_ItemDefaultInfoMap& ItemConf::FindItemDefaultInfo() const { return index_item_default_info_map_ ;}
+const ItemConf::Index_ItemDefaultInfoMap& ItemConf::FindItemDefaultInfoMap() const { return index_item_default_info_map_ ;}
 
 const ItemConf::Index_ItemDefaultInfoVector* ItemConf::FindItemDefaultInfo(const std::string& default_) const {
   auto iter = index_item_default_info_map_.find(default_);
@@ -181,7 +181,7 @@ const protoconf::ItemConf::Item* ItemConf::FindFirstItemDefaultInfo(const std::s
 }
 
 // Index: ExtType@ItemExtInfo
-const ItemConf::Index_ItemExtInfoMap& ItemConf::FindItemExtInfo() const { return index_item_ext_info_map_ ;}
+const ItemConf::Index_ItemExtInfoMap& ItemConf::FindItemExtInfoMap() const { return index_item_ext_info_map_ ;}
 
 const ItemConf::Index_ItemExtInfoVector* ItemConf::FindItemExtInfo(protoconf::FruitType ext_type) const {
   auto iter = index_item_ext_info_map_.find(ext_type);
@@ -200,7 +200,7 @@ const protoconf::ItemConf::Item* ItemConf::FindFirstItemExtInfo(protoconf::Fruit
 }
 
 // Index: (ID,Name)<Type,UseEffectType>@AwardItem
-const ItemConf::Index_AwardItemMap& ItemConf::FindAwardItem() const { return index_award_item_map_ ;}
+const ItemConf::Index_AwardItemMap& ItemConf::FindAwardItemMap() const { return index_award_item_map_ ;}
 
 const ItemConf::Index_AwardItemVector* ItemConf::FindAwardItem(uint32_t id, const std::string& name) const {
   auto iter = index_award_item_map_.find({id, name});
@@ -219,7 +219,7 @@ const protoconf::ItemConf::Item* ItemConf::FindFirstAwardItem(uint32_t id, const
 }
 
 // Index: (ID,Type,Param,ExtType)@SpecialItem
-const ItemConf::Index_SpecialItemMap& ItemConf::FindSpecialItem() const { return index_special_item_map_ ;}
+const ItemConf::Index_SpecialItemMap& ItemConf::FindSpecialItemMap() const { return index_special_item_map_ ;}
 
 const ItemConf::Index_SpecialItemVector* ItemConf::FindSpecialItem(uint32_t id, protoconf::FruitType type, int32_t param, protoconf::FruitType ext_type) const {
   auto iter = index_special_item_map_.find({id, type, param, ext_type});
@@ -238,7 +238,7 @@ const protoconf::ItemConf::Item* ItemConf::FindFirstSpecialItem(uint32_t id, pro
 }
 
 // Index: PathDir@ItemPathDir
-const ItemConf::Index_ItemPathDirMap& ItemConf::FindItemPathDir() const { return index_item_path_dir_map_ ;}
+const ItemConf::Index_ItemPathDirMap& ItemConf::FindItemPathDirMap() const { return index_item_path_dir_map_ ;}
 
 const ItemConf::Index_ItemPathDirVector* ItemConf::FindItemPathDir(const std::string& dir) const {
   auto iter = index_item_path_dir_map_.find(dir);
@@ -257,7 +257,7 @@ const protoconf::ItemConf::Item* ItemConf::FindFirstItemPathDir(const std::strin
 }
 
 // Index: PathName@ItemPathName
-const ItemConf::Index_ItemPathNameMap& ItemConf::FindItemPathName() const { return index_item_path_name_map_ ;}
+const ItemConf::Index_ItemPathNameMap& ItemConf::FindItemPathNameMap() const { return index_item_path_name_map_ ;}
 
 const ItemConf::Index_ItemPathNameVector* ItemConf::FindItemPathName(const std::string& name) const {
   auto iter = index_item_path_name_map_.find(name);
@@ -276,7 +276,7 @@ const protoconf::ItemConf::Item* ItemConf::FindFirstItemPathName(const std::stri
 }
 
 // Index: PathFriendID@ItemPathFriendID
-const ItemConf::Index_ItemPathFriendIDMap& ItemConf::FindItemPathFriendID() const { return index_item_path_friend_id_map_ ;}
+const ItemConf::Index_ItemPathFriendIDMap& ItemConf::FindItemPathFriendIDMap() const { return index_item_path_friend_id_map_ ;}
 
 const ItemConf::Index_ItemPathFriendIDVector* ItemConf::FindItemPathFriendID(uint32_t id) const {
   auto iter = index_item_path_friend_id_map_.find(id);
@@ -295,7 +295,7 @@ const protoconf::ItemConf::Item* ItemConf::FindFirstItemPathFriendID(uint32_t id
 }
 
 // Index: UseEffectType@UseEffectType
-const ItemConf::Index_UseEffectTypeMap& ItemConf::FindUseEffectType() const { return index_use_effect_type_map_ ;}
+const ItemConf::Index_UseEffectTypeMap& ItemConf::FindUseEffectTypeMap() const { return index_use_effect_type_map_ ;}
 
 const ItemConf::Index_UseEffectTypeVector* ItemConf::FindUseEffectType(protoconf::UseEffect::Type type) const {
   auto iter = index_use_effect_type_map_.find(type);

--- a/test/cpp-tableau-loader/src/protoconf/item_conf.pc.h
+++ b/test/cpp-tableau-loader/src/protoconf/item_conf.pc.h
@@ -46,9 +46,9 @@ class ItemConf : public Messager {
   // Finds the index (Type) to value (Index_ItemVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
   const Index_ItemMap& FindItemMap() const;
-  // Finds a vector of all values of the given key(s).
+  // Finds a vector of all values of the given key.
   const Index_ItemVector* FindItem(protoconf::FruitType type) const;
-  // Finds the first value of the given key(s).
+  // Finds the first value of the given key.
   const protoconf::ItemConf::Item* FindFirstItem(protoconf::FruitType type) const;
 
  private:
@@ -61,9 +61,9 @@ class ItemConf : public Messager {
   // Finds the index (Param<ID>@ItemInfo) to value (Index_ItemInfoVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
   const Index_ItemInfoMap& FindItemInfoMap() const;
-  // Finds a vector of all values of the given key(s).
+  // Finds a vector of all values of the given key.
   const Index_ItemInfoVector* FindItemInfo(int32_t param) const;
-  // Finds the first value of the given key(s).
+  // Finds the first value of the given key.
   const protoconf::ItemConf::Item* FindFirstItemInfo(int32_t param) const;
 
  private:
@@ -76,9 +76,9 @@ class ItemConf : public Messager {
   // Finds the index (Default@ItemDefaultInfo) to value (Index_ItemDefaultInfoVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
   const Index_ItemDefaultInfoMap& FindItemDefaultInfoMap() const;
-  // Finds a vector of all values of the given key(s).
+  // Finds a vector of all values of the given key.
   const Index_ItemDefaultInfoVector* FindItemDefaultInfo(const std::string& default_) const;
-  // Finds the first value of the given key(s).
+  // Finds the first value of the given key.
   const protoconf::ItemConf::Item* FindFirstItemDefaultInfo(const std::string& default_) const;
 
  private:
@@ -91,9 +91,9 @@ class ItemConf : public Messager {
   // Finds the index (ExtType@ItemExtInfo) to value (Index_ItemExtInfoVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
   const Index_ItemExtInfoMap& FindItemExtInfoMap() const;
-  // Finds a vector of all values of the given key(s).
+  // Finds a vector of all values of the given key.
   const Index_ItemExtInfoVector* FindItemExtInfo(protoconf::FruitType ext_type) const;
-  // Finds the first value of the given key(s).
+  // Finds the first value of the given key.
   const protoconf::ItemConf::Item* FindFirstItemExtInfo(protoconf::FruitType ext_type) const;
 
  private:
@@ -118,9 +118,9 @@ class ItemConf : public Messager {
   // Finds the index ((ID,Name)<Type,UseEffectType>@AwardItem) to value (Index_AwardItemVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
   const Index_AwardItemMap& FindAwardItemMap() const;
-  // Finds a vector of all values of the given key.
+  // Finds a vector of all values of the given keys.
   const Index_AwardItemVector* FindAwardItem(uint32_t id, const std::string& name) const;
-  // Finds the first value of the given key.
+  // Finds the first value of the given keys.
   const protoconf::ItemConf::Item* FindFirstAwardItem(uint32_t id, const std::string& name) const;
 
  private:
@@ -147,9 +147,9 @@ class ItemConf : public Messager {
   // Finds the index ((ID,Type,Param,ExtType)@SpecialItem) to value (Index_SpecialItemVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
   const Index_SpecialItemMap& FindSpecialItemMap() const;
-  // Finds a vector of all values of the given key.
+  // Finds a vector of all values of the given keys.
   const Index_SpecialItemVector* FindSpecialItem(uint32_t id, protoconf::FruitType type, int32_t param, protoconf::FruitType ext_type) const;
-  // Finds the first value of the given key.
+  // Finds the first value of the given keys.
   const protoconf::ItemConf::Item* FindFirstSpecialItem(uint32_t id, protoconf::FruitType type, int32_t param, protoconf::FruitType ext_type) const;
 
  private:
@@ -162,9 +162,9 @@ class ItemConf : public Messager {
   // Finds the index (PathDir@ItemPathDir) to value (Index_ItemPathDirVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
   const Index_ItemPathDirMap& FindItemPathDirMap() const;
-  // Finds a vector of all values of the given key(s).
+  // Finds a vector of all values of the given key.
   const Index_ItemPathDirVector* FindItemPathDir(const std::string& dir) const;
-  // Finds the first value of the given key(s).
+  // Finds the first value of the given key.
   const protoconf::ItemConf::Item* FindFirstItemPathDir(const std::string& dir) const;
 
  private:
@@ -177,9 +177,9 @@ class ItemConf : public Messager {
   // Finds the index (PathName@ItemPathName) to value (Index_ItemPathNameVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
   const Index_ItemPathNameMap& FindItemPathNameMap() const;
-  // Finds a vector of all values of the given key(s).
+  // Finds a vector of all values of the given key.
   const Index_ItemPathNameVector* FindItemPathName(const std::string& name) const;
-  // Finds the first value of the given key(s).
+  // Finds the first value of the given key.
   const protoconf::ItemConf::Item* FindFirstItemPathName(const std::string& name) const;
 
  private:
@@ -192,9 +192,9 @@ class ItemConf : public Messager {
   // Finds the index (PathFriendID@ItemPathFriendID) to value (Index_ItemPathFriendIDVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
   const Index_ItemPathFriendIDMap& FindItemPathFriendIDMap() const;
-  // Finds a vector of all values of the given key(s).
+  // Finds a vector of all values of the given key.
   const Index_ItemPathFriendIDVector* FindItemPathFriendID(uint32_t id) const;
-  // Finds the first value of the given key(s).
+  // Finds the first value of the given key.
   const protoconf::ItemConf::Item* FindFirstItemPathFriendID(uint32_t id) const;
 
  private:
@@ -207,9 +207,9 @@ class ItemConf : public Messager {
   // Finds the index (UseEffectType@UseEffectType) to value (Index_UseEffectTypeVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
   const Index_UseEffectTypeMap& FindUseEffectTypeMap() const;
-  // Finds a vector of all values of the given key(s).
+  // Finds a vector of all values of the given key.
   const Index_UseEffectTypeVector* FindUseEffectType(protoconf::UseEffect::Type type) const;
-  // Finds the first value of the given key(s).
+  // Finds the first value of the given key.
   const protoconf::ItemConf::Item* FindFirstUseEffectType(protoconf::UseEffect::Type type) const;
 
  private:

--- a/test/cpp-tableau-loader/src/protoconf/item_conf.pc.h
+++ b/test/cpp-tableau-loader/src/protoconf/item_conf.pc.h
@@ -45,10 +45,10 @@ class ItemConf : public Messager {
   using Index_ItemMap = std::unordered_map<protoconf::FruitType, Index_ItemVector>;
   // Finds the index (Type) to value (Index_ItemVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
-  const Index_ItemMap& FindItem() const;
-  // Finds a vector of all values of the given key.
+  const Index_ItemMap& FindItemMap() const;
+  // Finds a vector of all values of the given key(s).
   const Index_ItemVector* FindItem(protoconf::FruitType type) const;
-  // Finds the first value of the given key.
+  // Finds the first value of the given key(s).
   const protoconf::ItemConf::Item* FindFirstItem(protoconf::FruitType type) const;
 
  private:
@@ -60,10 +60,10 @@ class ItemConf : public Messager {
   using Index_ItemInfoMap = std::unordered_map<int32_t, Index_ItemInfoVector>;
   // Finds the index (Param<ID>@ItemInfo) to value (Index_ItemInfoVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
-  const Index_ItemInfoMap& FindItemInfo() const;
-  // Finds a vector of all values of the given key.
+  const Index_ItemInfoMap& FindItemInfoMap() const;
+  // Finds a vector of all values of the given key(s).
   const Index_ItemInfoVector* FindItemInfo(int32_t param) const;
-  // Finds the first value of the given key.
+  // Finds the first value of the given key(s).
   const protoconf::ItemConf::Item* FindFirstItemInfo(int32_t param) const;
 
  private:
@@ -75,10 +75,10 @@ class ItemConf : public Messager {
   using Index_ItemDefaultInfoMap = std::unordered_map<std::string, Index_ItemDefaultInfoVector>;
   // Finds the index (Default@ItemDefaultInfo) to value (Index_ItemDefaultInfoVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
-  const Index_ItemDefaultInfoMap& FindItemDefaultInfo() const;
-  // Finds a vector of all values of the given key.
+  const Index_ItemDefaultInfoMap& FindItemDefaultInfoMap() const;
+  // Finds a vector of all values of the given key(s).
   const Index_ItemDefaultInfoVector* FindItemDefaultInfo(const std::string& default_) const;
-  // Finds the first value of the given key.
+  // Finds the first value of the given key(s).
   const protoconf::ItemConf::Item* FindFirstItemDefaultInfo(const std::string& default_) const;
 
  private:
@@ -90,10 +90,10 @@ class ItemConf : public Messager {
   using Index_ItemExtInfoMap = std::unordered_map<protoconf::FruitType, Index_ItemExtInfoVector>;
   // Finds the index (ExtType@ItemExtInfo) to value (Index_ItemExtInfoVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
-  const Index_ItemExtInfoMap& FindItemExtInfo() const;
-  // Finds a vector of all values of the given key.
+  const Index_ItemExtInfoMap& FindItemExtInfoMap() const;
+  // Finds a vector of all values of the given key(s).
   const Index_ItemExtInfoVector* FindItemExtInfo(protoconf::FruitType ext_type) const;
-  // Finds the first value of the given key.
+  // Finds the first value of the given key(s).
   const protoconf::ItemConf::Item* FindFirstItemExtInfo(protoconf::FruitType ext_type) const;
 
  private:
@@ -117,7 +117,7 @@ class ItemConf : public Messager {
   using Index_AwardItemMap = std::unordered_map<Index_AwardItemKey, Index_AwardItemVector, Index_AwardItemKeyHasher>;
   // Finds the index ((ID,Name)<Type,UseEffectType>@AwardItem) to value (Index_AwardItemVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
-  const Index_AwardItemMap& FindAwardItem() const;
+  const Index_AwardItemMap& FindAwardItemMap() const;
   // Finds a vector of all values of the given key.
   const Index_AwardItemVector* FindAwardItem(uint32_t id, const std::string& name) const;
   // Finds the first value of the given key.
@@ -146,7 +146,7 @@ class ItemConf : public Messager {
   using Index_SpecialItemMap = std::unordered_map<Index_SpecialItemKey, Index_SpecialItemVector, Index_SpecialItemKeyHasher>;
   // Finds the index ((ID,Type,Param,ExtType)@SpecialItem) to value (Index_SpecialItemVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
-  const Index_SpecialItemMap& FindSpecialItem() const;
+  const Index_SpecialItemMap& FindSpecialItemMap() const;
   // Finds a vector of all values of the given key.
   const Index_SpecialItemVector* FindSpecialItem(uint32_t id, protoconf::FruitType type, int32_t param, protoconf::FruitType ext_type) const;
   // Finds the first value of the given key.
@@ -161,10 +161,10 @@ class ItemConf : public Messager {
   using Index_ItemPathDirMap = std::unordered_map<std::string, Index_ItemPathDirVector>;
   // Finds the index (PathDir@ItemPathDir) to value (Index_ItemPathDirVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
-  const Index_ItemPathDirMap& FindItemPathDir() const;
-  // Finds a vector of all values of the given key.
+  const Index_ItemPathDirMap& FindItemPathDirMap() const;
+  // Finds a vector of all values of the given key(s).
   const Index_ItemPathDirVector* FindItemPathDir(const std::string& dir) const;
-  // Finds the first value of the given key.
+  // Finds the first value of the given key(s).
   const protoconf::ItemConf::Item* FindFirstItemPathDir(const std::string& dir) const;
 
  private:
@@ -176,10 +176,10 @@ class ItemConf : public Messager {
   using Index_ItemPathNameMap = std::unordered_map<std::string, Index_ItemPathNameVector>;
   // Finds the index (PathName@ItemPathName) to value (Index_ItemPathNameVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
-  const Index_ItemPathNameMap& FindItemPathName() const;
-  // Finds a vector of all values of the given key.
+  const Index_ItemPathNameMap& FindItemPathNameMap() const;
+  // Finds a vector of all values of the given key(s).
   const Index_ItemPathNameVector* FindItemPathName(const std::string& name) const;
-  // Finds the first value of the given key.
+  // Finds the first value of the given key(s).
   const protoconf::ItemConf::Item* FindFirstItemPathName(const std::string& name) const;
 
  private:
@@ -191,10 +191,10 @@ class ItemConf : public Messager {
   using Index_ItemPathFriendIDMap = std::unordered_map<uint32_t, Index_ItemPathFriendIDVector>;
   // Finds the index (PathFriendID@ItemPathFriendID) to value (Index_ItemPathFriendIDVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
-  const Index_ItemPathFriendIDMap& FindItemPathFriendID() const;
-  // Finds a vector of all values of the given key.
+  const Index_ItemPathFriendIDMap& FindItemPathFriendIDMap() const;
+  // Finds a vector of all values of the given key(s).
   const Index_ItemPathFriendIDVector* FindItemPathFriendID(uint32_t id) const;
-  // Finds the first value of the given key.
+  // Finds the first value of the given key(s).
   const protoconf::ItemConf::Item* FindFirstItemPathFriendID(uint32_t id) const;
 
  private:
@@ -206,10 +206,10 @@ class ItemConf : public Messager {
   using Index_UseEffectTypeMap = std::unordered_map<protoconf::UseEffect::Type, Index_UseEffectTypeVector>;
   // Finds the index (UseEffectType@UseEffectType) to value (Index_UseEffectTypeVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
-  const Index_UseEffectTypeMap& FindUseEffectType() const;
-  // Finds a vector of all values of the given key.
+  const Index_UseEffectTypeMap& FindUseEffectTypeMap() const;
+  // Finds a vector of all values of the given key(s).
   const Index_UseEffectTypeVector* FindUseEffectType(protoconf::UseEffect::Type type) const;
-  // Finds the first value of the given key.
+  // Finds the first value of the given key(s).
   const protoconf::ItemConf::Item* FindFirstUseEffectType(protoconf::UseEffect::Type type) const;
 
  private:

--- a/test/cpp-tableau-loader/src/protoconf/item_conf.pc.h
+++ b/test/cpp-tableau-loader/src/protoconf/item_conf.pc.h
@@ -119,9 +119,9 @@ class ItemConf : public Messager {
   // One key may correspond to multiple values, which are contained by a vector.
   const Index_AwardItemMap& FindAwardItem() const;
   // Finds a vector of all values of the given key.
-  const Index_AwardItemVector* FindAwardItem(const Index_AwardItemKey& key) const;
+  const Index_AwardItemVector* FindAwardItem(uint32_t id, const std::string& name) const;
   // Finds the first value of the given key.
-  const protoconf::ItemConf::Item* FindFirstAwardItem(const Index_AwardItemKey& key) const;
+  const protoconf::ItemConf::Item* FindFirstAwardItem(uint32_t id, const std::string& name) const;
 
  private:
   Index_AwardItemMap index_award_item_map_;
@@ -148,9 +148,9 @@ class ItemConf : public Messager {
   // One key may correspond to multiple values, which are contained by a vector.
   const Index_SpecialItemMap& FindSpecialItem() const;
   // Finds a vector of all values of the given key.
-  const Index_SpecialItemVector* FindSpecialItem(const Index_SpecialItemKey& key) const;
+  const Index_SpecialItemVector* FindSpecialItem(uint32_t id, protoconf::FruitType type, int32_t param, protoconf::FruitType ext_type) const;
   // Finds the first value of the given key.
-  const protoconf::ItemConf::Item* FindFirstSpecialItem(const Index_SpecialItemKey& key) const;
+  const protoconf::ItemConf::Item* FindFirstSpecialItem(uint32_t id, protoconf::FruitType type, int32_t param, protoconf::FruitType ext_type) const;
 
  private:
   Index_SpecialItemMap index_special_item_map_;

--- a/test/cpp-tableau-loader/src/protoconf/test_conf.pc.cc
+++ b/test/cpp-tableau-loader/src/protoconf/test_conf.pc.cc
@@ -162,7 +162,7 @@ const ActivityConf::int32_OrderedMap* ActivityConf::GetOrderedMap(uint64_t activ
 }
 
 // Index: ActivityName
-const ActivityConf::Index_ActivityMap& ActivityConf::FindActivity() const { return index_activity_map_ ;}
+const ActivityConf::Index_ActivityMap& ActivityConf::FindActivityMap() const { return index_activity_map_ ;}
 
 const ActivityConf::Index_ActivityVector* ActivityConf::FindActivity(const std::string& activity_name) const {
   auto iter = index_activity_map_.find(activity_name);
@@ -181,7 +181,7 @@ const protoconf::ActivityConf::Activity* ActivityConf::FindFirstActivity(const s
 }
 
 // Index: ChapterID
-const ActivityConf::Index_ChapterMap& ActivityConf::FindChapter() const { return index_chapter_map_ ;}
+const ActivityConf::Index_ChapterMap& ActivityConf::FindChapterMap() const { return index_chapter_map_ ;}
 
 const ActivityConf::Index_ChapterVector* ActivityConf::FindChapter(uint32_t chapter_id) const {
   auto iter = index_chapter_map_.find(chapter_id);
@@ -200,7 +200,7 @@ const protoconf::ActivityConf::Activity::Chapter* ActivityConf::FindFirstChapter
 }
 
 // Index: ChapterName<AwardID>@NamedChapter
-const ActivityConf::Index_NamedChapterMap& ActivityConf::FindNamedChapter() const { return index_named_chapter_map_ ;}
+const ActivityConf::Index_NamedChapterMap& ActivityConf::FindNamedChapterMap() const { return index_named_chapter_map_ ;}
 
 const ActivityConf::Index_NamedChapterVector* ActivityConf::FindNamedChapter(const std::string& chapter_name) const {
   auto iter = index_named_chapter_map_.find(chapter_name);
@@ -219,7 +219,7 @@ const protoconf::ActivityConf::Activity::Chapter* ActivityConf::FindFirstNamedCh
 }
 
 // Index: SectionItemID@Award
-const ActivityConf::Index_AwardMap& ActivityConf::FindAward() const { return index_award_map_ ;}
+const ActivityConf::Index_AwardMap& ActivityConf::FindAwardMap() const { return index_award_map_ ;}
 
 const ActivityConf::Index_AwardVector* ActivityConf::FindAward(uint32_t id) const {
   auto iter = index_award_map_.find(id);
@@ -362,7 +362,7 @@ const protoconf::TaskConf::Task* TaskConf::Get(int64_t id) const {
 }
 
 // Index: ActivityID<Goal,ID>
-const TaskConf::Index_TaskMap& TaskConf::FindTask() const { return index_task_map_ ;}
+const TaskConf::Index_TaskMap& TaskConf::FindTaskMap() const { return index_task_map_ ;}
 
 const TaskConf::Index_TaskVector* TaskConf::FindTask(int64_t activity_id) const {
   auto iter = index_task_map_.find(activity_id);

--- a/test/cpp-tableau-loader/src/protoconf/test_conf.pc.h
+++ b/test/cpp-tableau-loader/src/protoconf/test_conf.pc.h
@@ -61,9 +61,9 @@ class ActivityConf : public Messager {
   // Finds the index (ActivityName) to value (Index_ActivityVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
   const Index_ActivityMap& FindActivityMap() const;
-  // Finds a vector of all values of the given key(s).
+  // Finds a vector of all values of the given key.
   const Index_ActivityVector* FindActivity(const std::string& activity_name) const;
-  // Finds the first value of the given key(s).
+  // Finds the first value of the given key.
   const protoconf::ActivityConf::Activity* FindFirstActivity(const std::string& activity_name) const;
 
  private:
@@ -76,9 +76,9 @@ class ActivityConf : public Messager {
   // Finds the index (ChapterID) to value (Index_ChapterVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
   const Index_ChapterMap& FindChapterMap() const;
-  // Finds a vector of all values of the given key(s).
+  // Finds a vector of all values of the given key.
   const Index_ChapterVector* FindChapter(uint32_t chapter_id) const;
-  // Finds the first value of the given key(s).
+  // Finds the first value of the given key.
   const protoconf::ActivityConf::Activity::Chapter* FindFirstChapter(uint32_t chapter_id) const;
 
  private:
@@ -91,9 +91,9 @@ class ActivityConf : public Messager {
   // Finds the index (ChapterName<AwardID>@NamedChapter) to value (Index_NamedChapterVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
   const Index_NamedChapterMap& FindNamedChapterMap() const;
-  // Finds a vector of all values of the given key(s).
+  // Finds a vector of all values of the given key.
   const Index_NamedChapterVector* FindNamedChapter(const std::string& chapter_name) const;
-  // Finds the first value of the given key(s).
+  // Finds the first value of the given key.
   const protoconf::ActivityConf::Activity::Chapter* FindFirstNamedChapter(const std::string& chapter_name) const;
 
  private:
@@ -106,9 +106,9 @@ class ActivityConf : public Messager {
   // Finds the index (SectionItemID@Award) to value (Index_AwardVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
   const Index_AwardMap& FindAwardMap() const;
-  // Finds a vector of all values of the given key(s).
+  // Finds a vector of all values of the given key.
   const Index_AwardVector* FindAward(uint32_t id) const;
-  // Finds the first value of the given key(s).
+  // Finds the first value of the given key.
   const protoconf::Section::SectionItem* FindFirstAward(uint32_t id) const;
 
  private:
@@ -172,9 +172,9 @@ class TaskConf : public Messager {
   // Finds the index (ActivityID<Goal,ID>) to value (Index_TaskVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
   const Index_TaskMap& FindTaskMap() const;
-  // Finds a vector of all values of the given key(s).
+  // Finds a vector of all values of the given key.
   const Index_TaskVector* FindTask(int64_t activity_id) const;
-  // Finds the first value of the given key(s).
+  // Finds the first value of the given key.
   const protoconf::TaskConf::Task* FindFirstTask(int64_t activity_id) const;
 
  private:

--- a/test/cpp-tableau-loader/src/protoconf/test_conf.pc.h
+++ b/test/cpp-tableau-loader/src/protoconf/test_conf.pc.h
@@ -60,10 +60,10 @@ class ActivityConf : public Messager {
   using Index_ActivityMap = std::unordered_map<std::string, Index_ActivityVector>;
   // Finds the index (ActivityName) to value (Index_ActivityVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
-  const Index_ActivityMap& FindActivity() const;
-  // Finds a vector of all values of the given key.
+  const Index_ActivityMap& FindActivityMap() const;
+  // Finds a vector of all values of the given key(s).
   const Index_ActivityVector* FindActivity(const std::string& activity_name) const;
-  // Finds the first value of the given key.
+  // Finds the first value of the given key(s).
   const protoconf::ActivityConf::Activity* FindFirstActivity(const std::string& activity_name) const;
 
  private:
@@ -75,10 +75,10 @@ class ActivityConf : public Messager {
   using Index_ChapterMap = std::unordered_map<uint32_t, Index_ChapterVector>;
   // Finds the index (ChapterID) to value (Index_ChapterVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
-  const Index_ChapterMap& FindChapter() const;
-  // Finds a vector of all values of the given key.
+  const Index_ChapterMap& FindChapterMap() const;
+  // Finds a vector of all values of the given key(s).
   const Index_ChapterVector* FindChapter(uint32_t chapter_id) const;
-  // Finds the first value of the given key.
+  // Finds the first value of the given key(s).
   const protoconf::ActivityConf::Activity::Chapter* FindFirstChapter(uint32_t chapter_id) const;
 
  private:
@@ -90,10 +90,10 @@ class ActivityConf : public Messager {
   using Index_NamedChapterMap = std::unordered_map<std::string, Index_NamedChapterVector>;
   // Finds the index (ChapterName<AwardID>@NamedChapter) to value (Index_NamedChapterVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
-  const Index_NamedChapterMap& FindNamedChapter() const;
-  // Finds a vector of all values of the given key.
+  const Index_NamedChapterMap& FindNamedChapterMap() const;
+  // Finds a vector of all values of the given key(s).
   const Index_NamedChapterVector* FindNamedChapter(const std::string& chapter_name) const;
-  // Finds the first value of the given key.
+  // Finds the first value of the given key(s).
   const protoconf::ActivityConf::Activity::Chapter* FindFirstNamedChapter(const std::string& chapter_name) const;
 
  private:
@@ -105,10 +105,10 @@ class ActivityConf : public Messager {
   using Index_AwardMap = std::unordered_map<uint32_t, Index_AwardVector>;
   // Finds the index (SectionItemID@Award) to value (Index_AwardVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
-  const Index_AwardMap& FindAward() const;
-  // Finds a vector of all values of the given key.
+  const Index_AwardMap& FindAwardMap() const;
+  // Finds a vector of all values of the given key(s).
   const Index_AwardVector* FindAward(uint32_t id) const;
-  // Finds the first value of the given key.
+  // Finds the first value of the given key(s).
   const protoconf::Section::SectionItem* FindFirstAward(uint32_t id) const;
 
  private:
@@ -171,10 +171,10 @@ class TaskConf : public Messager {
   using Index_TaskMap = std::unordered_map<int64_t, Index_TaskVector>;
   // Finds the index (ActivityID<Goal,ID>) to value (Index_TaskVector) hash map.
   // One key may correspond to multiple values, which are contained by a vector.
-  const Index_TaskMap& FindTask() const;
-  // Finds a vector of all values of the given key.
+  const Index_TaskMap& FindTaskMap() const;
+  // Finds a vector of all values of the given key(s).
   const Index_TaskVector* FindTask(int64_t activity_id) const;
-  // Finds the first value of the given key.
+  // Finds the first value of the given key(s).
   const protoconf::TaskConf::Task* FindFirstTask(int64_t activity_id) const;
 
  private:

--- a/test/go-tableau-loader/protoconf/loader/hero_conf.pc.go
+++ b/test/go-tableau-loader/protoconf/loader/hero_conf.pc.go
@@ -151,7 +151,7 @@ func (x *HeroConf) FindAttr(title string) []*protoconf.HeroConf_Hero_Attr {
 // FindFirstAttr finds the first value of the given key,
 // or nil if no value found.
 func (x *HeroConf) FindFirstAttr(title string) *protoconf.HeroConf_Hero_Attr {
-	val := x.indexAttrMap[title]
+	val := x.FindAttr(title)
 	if len(val) > 0 {
 		return val[0]
 	}

--- a/test/go-tableau-loader/protoconf/loader/item_conf.pc.go
+++ b/test/go-tableau-loader/protoconf/loader/item_conf.pc.go
@@ -273,7 +273,7 @@ func (x *ItemConf) FindItem(type_ protoconf.FruitType) []*protoconf.ItemConf_Ite
 // FindFirstItem finds the first value of the given key,
 // or nil if no value found.
 func (x *ItemConf) FindFirstItem(type_ protoconf.FruitType) *protoconf.ItemConf_Item {
-	val := x.indexItemMap[type_]
+	val := x.FindItem(type_)
 	if len(val) > 0 {
 		return val[0]
 	}
@@ -296,7 +296,7 @@ func (x *ItemConf) FindItemInfo(param int32) []*protoconf.ItemConf_Item {
 // FindFirstItemInfo finds the first value of the given key,
 // or nil if no value found.
 func (x *ItemConf) FindFirstItemInfo(param int32) *protoconf.ItemConf_Item {
-	val := x.indexItemInfoMap[param]
+	val := x.FindItemInfo(param)
 	if len(val) > 0 {
 		return val[0]
 	}
@@ -319,7 +319,7 @@ func (x *ItemConf) FindItemDefaultInfo(default_ string) []*protoconf.ItemConf_It
 // FindFirstItemDefaultInfo finds the first value of the given key,
 // or nil if no value found.
 func (x *ItemConf) FindFirstItemDefaultInfo(default_ string) *protoconf.ItemConf_Item {
-	val := x.indexItemDefaultInfoMap[default_]
+	val := x.FindItemDefaultInfo(default_)
 	if len(val) > 0 {
 		return val[0]
 	}
@@ -342,7 +342,7 @@ func (x *ItemConf) FindItemExtInfo(extType protoconf.FruitType) []*protoconf.Ite
 // FindFirstItemExtInfo finds the first value of the given key,
 // or nil if no value found.
 func (x *ItemConf) FindFirstItemExtInfo(extType protoconf.FruitType) *protoconf.ItemConf_Item {
-	val := x.indexItemExtInfoMap[extType]
+	val := x.FindItemExtInfo(extType)
 	if len(val) > 0 {
 		return val[0]
 	}
@@ -358,14 +358,14 @@ func (x *ItemConf) FindAwardItemMap() ItemConf_Index_AwardItemMap {
 }
 
 // FindAwardItem finds a slice of all values of the given key.
-func (x *ItemConf) FindAwardItem(key ItemConf_Index_AwardItemKey) []*protoconf.ItemConf_Item {
-	return x.indexAwardItemMap[key]
+func (x *ItemConf) FindAwardItem(id uint32, name string) []*protoconf.ItemConf_Item {
+	return x.indexAwardItemMap[ItemConf_Index_AwardItemKey{id, name}]
 }
 
 // FindFirstAwardItem finds the first value of the given key,
 // or nil if no value found.
-func (x *ItemConf) FindFirstAwardItem(key ItemConf_Index_AwardItemKey) *protoconf.ItemConf_Item {
-	val := x.indexAwardItemMap[key]
+func (x *ItemConf) FindFirstAwardItem(id uint32, name string) *protoconf.ItemConf_Item {
+	val := x.FindAwardItem(id, name)
 	if len(val) > 0 {
 		return val[0]
 	}
@@ -381,14 +381,14 @@ func (x *ItemConf) FindSpecialItemMap() ItemConf_Index_SpecialItemMap {
 }
 
 // FindSpecialItem finds a slice of all values of the given key.
-func (x *ItemConf) FindSpecialItem(key ItemConf_Index_SpecialItemKey) []*protoconf.ItemConf_Item {
-	return x.indexSpecialItemMap[key]
+func (x *ItemConf) FindSpecialItem(id uint32, type_ protoconf.FruitType, param int32, extType protoconf.FruitType) []*protoconf.ItemConf_Item {
+	return x.indexSpecialItemMap[ItemConf_Index_SpecialItemKey{id, type_, param, extType}]
 }
 
 // FindFirstSpecialItem finds the first value of the given key,
 // or nil if no value found.
-func (x *ItemConf) FindFirstSpecialItem(key ItemConf_Index_SpecialItemKey) *protoconf.ItemConf_Item {
-	val := x.indexSpecialItemMap[key]
+func (x *ItemConf) FindFirstSpecialItem(id uint32, type_ protoconf.FruitType, param int32, extType protoconf.FruitType) *protoconf.ItemConf_Item {
+	val := x.FindSpecialItem(id, type_, param, extType)
 	if len(val) > 0 {
 		return val[0]
 	}
@@ -411,7 +411,7 @@ func (x *ItemConf) FindItemPathDir(dir string) []*protoconf.ItemConf_Item {
 // FindFirstItemPathDir finds the first value of the given key,
 // or nil if no value found.
 func (x *ItemConf) FindFirstItemPathDir(dir string) *protoconf.ItemConf_Item {
-	val := x.indexItemPathDirMap[dir]
+	val := x.FindItemPathDir(dir)
 	if len(val) > 0 {
 		return val[0]
 	}
@@ -434,7 +434,7 @@ func (x *ItemConf) FindItemPathName(name string) []*protoconf.ItemConf_Item {
 // FindFirstItemPathName finds the first value of the given key,
 // or nil if no value found.
 func (x *ItemConf) FindFirstItemPathName(name string) *protoconf.ItemConf_Item {
-	val := x.indexItemPathNameMap[name]
+	val := x.FindItemPathName(name)
 	if len(val) > 0 {
 		return val[0]
 	}
@@ -457,7 +457,7 @@ func (x *ItemConf) FindItemPathFriendID(id uint32) []*protoconf.ItemConf_Item {
 // FindFirstItemPathFriendID finds the first value of the given key,
 // or nil if no value found.
 func (x *ItemConf) FindFirstItemPathFriendID(id uint32) *protoconf.ItemConf_Item {
-	val := x.indexItemPathFriendIdMap[id]
+	val := x.FindItemPathFriendID(id)
 	if len(val) > 0 {
 		return val[0]
 	}
@@ -480,7 +480,7 @@ func (x *ItemConf) FindUseEffectType(type_ protoconf.UseEffect_Type) []*protocon
 // FindFirstUseEffectType finds the first value of the given key,
 // or nil if no value found.
 func (x *ItemConf) FindFirstUseEffectType(type_ protoconf.UseEffect_Type) *protoconf.ItemConf_Item {
-	val := x.indexUseEffectTypeMap[type_]
+	val := x.FindUseEffectType(type_)
 	if len(val) > 0 {
 		return val[0]
 	}

--- a/test/go-tableau-loader/protoconf/loader/test_conf.pc.go
+++ b/test/go-tableau-loader/protoconf/loader/test_conf.pc.go
@@ -308,7 +308,7 @@ func (x *ActivityConf) FindActivity(activityName string) []*protoconf.ActivityCo
 // FindFirstActivity finds the first value of the given key,
 // or nil if no value found.
 func (x *ActivityConf) FindFirstActivity(activityName string) *protoconf.ActivityConf_Activity {
-	val := x.indexActivityMap[activityName]
+	val := x.FindActivity(activityName)
 	if len(val) > 0 {
 		return val[0]
 	}
@@ -331,7 +331,7 @@ func (x *ActivityConf) FindChapter(chapterId uint32) []*protoconf.ActivityConf_A
 // FindFirstChapter finds the first value of the given key,
 // or nil if no value found.
 func (x *ActivityConf) FindFirstChapter(chapterId uint32) *protoconf.ActivityConf_Activity_Chapter {
-	val := x.indexChapterMap[chapterId]
+	val := x.FindChapter(chapterId)
 	if len(val) > 0 {
 		return val[0]
 	}
@@ -354,7 +354,7 @@ func (x *ActivityConf) FindNamedChapter(chapterName string) []*protoconf.Activit
 // FindFirstNamedChapter finds the first value of the given key,
 // or nil if no value found.
 func (x *ActivityConf) FindFirstNamedChapter(chapterName string) *protoconf.ActivityConf_Activity_Chapter {
-	val := x.indexNamedChapterMap[chapterName]
+	val := x.FindNamedChapter(chapterName)
 	if len(val) > 0 {
 		return val[0]
 	}
@@ -377,7 +377,7 @@ func (x *ActivityConf) FindAward(id uint32) []*protoconf.Section_SectionItem {
 // FindFirstAward finds the first value of the given key,
 // or nil if no value found.
 func (x *ActivityConf) FindFirstAward(id uint32) *protoconf.Section_SectionItem {
-	val := x.indexAwardMap[id]
+	val := x.FindAward(id)
 	if len(val) > 0 {
 		return val[0]
 	}
@@ -737,7 +737,7 @@ func (x *TaskConf) FindTask(activityId int64) []*protoconf.TaskConf_Task {
 // FindFirstTask finds the first value of the given key,
 // or nil if no value found.
 func (x *TaskConf) FindFirstTask(activityId int64) *protoconf.TaskConf_Task {
-	val := x.indexTaskMap[activityId]
+	val := x.FindTask(activityId)
 	if len(val) > 0 {
 		return val[0]
 	}


### PR DESCRIPTION
- close #135

## Breaking change
Multiple-column index finder arguments are changed from the key struct to flattened params.

### Go
```go
// Previous
func (x *ItemConf) FindAwardItem(key ItemConf_Index_AwardItemKey) []*protoconf.ItemConf_Item {
    ...
}
// Current
func (x *ItemConf) FindAwardItem(id uint32, name string) []*protoconf.ItemConf_Item {
    ...
}
```

### Cpp
```cpp
// Previous
const Index_AwardItemVector* FindAwardItem(const Index_AwardItemKey& key) const;
// Current
const Index_AwardItemVector* FindAwardItem(uint32_t id, const std::string& name) const;
```
Add `Map` suffix when access underlying hash or ordered map
```cpp
// Previous
const ItemConf::Index_AwardItemMap& ItemConf::FindAwardItem() const
// Current
const ItemConf::Index_AwardItemMap& ItemConf::FindAwardItemMap() const
```